### PR TITLE
[Bugfix]: Return false if no launch configuration is found

### DIFF
--- a/src/main/java/gyro/aws/autoscaling/LaunchConfigurationResource.java
+++ b/src/main/java/gyro/aws/autoscaling/LaunchConfigurationResource.java
@@ -290,7 +290,7 @@ public class LaunchConfigurationResource extends AwsResource {
     public String toDisplayString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("Launch Configuration");
+        sb.append("launch configuration");
 
         if (!ObjectUtils.isBlank(getLaunchConfigurationName())) {
             sb.append(" - ").append(getLaunchConfigurationName());


### PR DESCRIPTION
This prevented Gyro from detecting when a launch configuration was deleted and needed to be recreated.

The exception logic in `refresh()` still needs to be looked at since this fix implies that the SDK does not trigger an expection if the launch configuration isn't found.