### PR TITLE
GYRO-213: Fix Adding ElasticIP to existing Instance goes undetected.

### DIFF
--- a/src/main/java/gyro/aws/ec2/ElasticIpResource.java
+++ b/src/main/java/gyro/aws/ec2/ElasticIpResource.java
@@ -221,6 +221,8 @@ public class ElasticIpResource extends Ec2TaggableResource<Address> implements C
                 throw new GyroException(MessageFormat.format("Elastic Ip - {0} Unavailable/Not found.", getPublicIp()));
             } else if (eex.awsErrorDetails().errorCode().equals("AddressLimitExceeded")) {
                 throw new GyroException("The maximum number of addresses has been reached.");
+            } else {
+                throw eex;
             }
         }
     }


### PR DESCRIPTION
The reason elastic ip attachment was undetected was there was an error during attachment that was not thrown during creation. 
Throwing the caught exception if it does not satisfy the condition fixes it.