### PR TITLE
GYRO-252: Fix Security Group with two rules using the same port causes issues.

### DIFF
--- a/src/main/java/gyro/aws/ec2/SecurityGroupRuleResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupRuleResource.java
@@ -121,8 +121,8 @@ public abstract class SecurityGroupRuleResource extends AwsResource {
             sb.append(getCidrBlock());
         } else if (!ObjectUtils.isBlank(getIpv6CidrBlock())) {
             sb.append(getIpv6CidrBlock());
-        } else if (getSecurityGroup() != null && !ObjectUtils.isBlank(getSecurityGroup().getGroupId())){
-            sb.append(getSecurityGroup().getGroupId());
+        } else if (getSecurityGroup() != null && !ObjectUtils.isBlank(getSecurityGroup().getId())){
+            sb.append(getSecurityGroup().getId());
         }
 
         return sb.toString();


### PR DESCRIPTION
Modify attribute reference from 'group-id' to 'id'.