### PR TITLE
GYRO-298: Can't create new s3 buckets without domain-name set.

### DIFF
--- a/src/main/java/gyro/aws/s3/BucketResource.java
+++ b/src/main/java/gyro/aws/s3/BucketResource.java
@@ -136,7 +136,6 @@ public class BucketResource extends AwsResource implements Copyable<Bucket> {
     private String requestPayer;
     private List<S3CorsRule> corsRule;
     private List<S3LifecycleRule> lifecycleRule;
-    private String domainName;
 
     @Id
     public String getName() {
@@ -265,24 +264,6 @@ public class BucketResource extends AwsResource implements Copyable<Bucket> {
         this.lifecycleRule = lifecycleRule;
     }
 
-    @Output
-    public String getDomainName() {
-        if (domainName == null) {
-            S3Client client = createClient(S3Client.class);
-            try {
-                domainName = String.format("%s.s3.%s.amazonaws.com", getName(), getBucketRegion(client));
-            } catch (GyroException ignore) {
-                //ignore
-            }
-        }
-
-        return domainName;
-    }
-
-    public void setDomainName(String domainName) {
-        this.domainName = domainName;
-    }
-
     @Override
     public void copyFrom(Bucket bucket) {
         S3Client client = createClient(S3Client.class);
@@ -318,7 +299,6 @@ public class BucketResource extends AwsResource implements Copyable<Bucket> {
             r -> r.bucket(getName())
                 .objectLockEnabledForBucket(getEnableObjectLock())
         );
-        setDomainName(String.format("%s.s3.%s.amazonaws.com", getName(), getBucketRegion(client)));
 
         if (!getTags().isEmpty()) {
             saveTags(client);
@@ -572,6 +552,11 @@ public class BucketResource extends AwsResource implements Copyable<Bucket> {
                     )
             );
         }
+    }
+
+    public String getDomainName() {
+        S3Client client = createClient(S3Client.class);
+        return String.format("%s.s3.%s.amazonaws.com", getName(), getBucketRegion(client));
     }
 
     private String getBucketRegion(S3Client client) {


### PR DESCRIPTION
The domain name getter searches for the region based on a bucket name. If it fails the getter should resolve to the default domain name, rather than throwing an exception.

This handles the error that occurs when creating a new bucket, where the `getDomainName ()` fails as the bucket does not exist when querying for the region.