### PR TITLE
GYRO-313: Remove arn field from launch configuration resource

### DIFF
--- a/src/main/java/gyro/aws/autoscaling/LaunchConfigurationResource.java
+++ b/src/main/java/gyro/aws/autoscaling/LaunchConfigurationResource.java
@@ -87,8 +87,6 @@ public class LaunchConfigurationResource extends AwsResource implements Copyable
     private Set<BlockDeviceMappingResource> blockDeviceMapping;
     private InstanceProfileResource instanceProfile;
 
-    private String arn;
-
     /**
      * The name of the launch configuration. (Required)
      */


### PR DESCRIPTION
This field is not set during creation and appears to never been needed by another other resources.