### PR TITLE
GYRO-340: Fix record set issue showing a diff if a name is given without a trailing (.)

### DIFF
--- a/src/main/java/gyro/aws/route53/RecordSetResource.java
+++ b/src/main/java/gyro/aws/route53/RecordSetResource.java
@@ -196,6 +196,10 @@ public class RecordSetResource extends AwsResource implements Copyable<ResourceR
      */
     @Updatable
     public String getName() {
+        if (name != null) {
+            name = StringUtils.ensureEnd(name, ".");
+        }
+
         return name;
     }
 


### PR DESCRIPTION
This solves the issue of a constant change if a name is given without a trailing period (.), as the name returned has a period.