### PR TITLE
GYRO-350: Don't set dhcp-options to default, this removes them

### DIFF
--- a/src/main/java/gyro/aws/ec2/VpcResource.java
+++ b/src/main/java/gyro/aws/ec2/VpcResource.java
@@ -414,8 +414,6 @@ public class VpcResource extends Ec2TaggableResource<Vpc> implements Copyable<Vp
         if (changedProperties.isEmpty() || changedProperties.contains("dhcp-options")) {
             if (getDhcpOptions() != null) {
                 client.associateDhcpOptions(r -> r.dhcpOptionsId(getDhcpOptions().getId()).vpcId(getId()));
-            } else {
-                client.associateDhcpOptions(r -> r.vpcId(getId()).dhcpOptionsId("default"));
             }
         }
 


### PR DESCRIPTION
"default" means "I don't want any options" rather than "I want the default options". Confusing, I know.