### PR TITLE
GYRO-364: Elastic IP says it will update tags but never does

### DIFF
--- a/src/main/java/gyro/aws/ec2/ElasticIpResource.java
+++ b/src/main/java/gyro/aws/ec2/ElasticIpResource.java
@@ -168,14 +168,7 @@ public class ElasticIpResource extends Ec2TaggableResource<Address> implements C
 
     @Override
     public void copyFrom(Address address) {
-        setId(address.allocationId());
-        setIsStandardDomain(address.domain().equals(DomainType.STANDARD));
-        setPublicIp(address.publicIp());
-        setNetworkInterface(!ObjectUtils.isBlank(address.networkInterfaceId()) ? findById(NetworkInterfaceResource.class, address.networkInterfaceId()) : null);
-        setInstance(!ObjectUtils.isBlank(address.instanceId()) ? findById(InstanceResource.class, address.instanceId()) : null);
-        setAssociationId(address.associationId());
-
-        refreshTags();
+        loadAddress(address, true);
     }
 
     @Override
@@ -278,7 +271,7 @@ public class ElasticIpResource extends Ec2TaggableResource<Address> implements C
             }
         }
 
-        doRefresh();
+        loadAddress(getAddress(client), false);
     }
 
     @Override
@@ -329,5 +322,18 @@ public class ElasticIpResource extends Ec2TaggableResource<Address> implements C
         }
 
         return address;
+    }
+
+    private void loadAddress(Address address, boolean refreshTags) {
+        setId(address.allocationId());
+        setIsStandardDomain(address.domain().equals(DomainType.STANDARD));
+        setPublicIp(address.publicIp());
+        setNetworkInterface(!ObjectUtils.isBlank(address.networkInterfaceId()) ? findById(NetworkInterfaceResource.class, address.networkInterfaceId()) : null);
+        setInstance(!ObjectUtils.isBlank(address.instanceId()) ? findById(InstanceResource.class, address.instanceId()) : null);
+        setAssociationId(address.associationId());
+
+        if (refreshTags) {
+            refreshTags();
+        }
     }
 }


### PR DESCRIPTION
Previous implementation was refreshing tags on elastic ip update. As updates to tags are handled in the super class `Ec2TaggableResource`, which updates `tags` after the specific resource update, calling the `doRefresh` method after the resource update was clearing the modified tags.

The current approach refreshes the resource after update without refreshing the tags.