### PR TITLE
GYRO-364: Elastic IP says it will update tags but never does.

### DIFF
--- a/src/main/java/gyro/aws/ec2/ElasticIpResource.java
+++ b/src/main/java/gyro/aws/ec2/ElasticIpResource.java
@@ -277,8 +277,6 @@ public class ElasticIpResource extends Ec2TaggableResource<Address> implements C
                 }
             }
         }
-
-        doRefresh();
     }
 
     @Override


### PR DESCRIPTION
The `doRefresh` updates the tags from the cloud before `Ec2TaggableResource` can update the tags from the config, whihc results in the tags to be not updated.

All the updatable values are already set in the update and as such the `doRefresh ` is a redundant call.