### PR TITLE
GYRO-394: Set default certificate correctly

### DIFF
--- a/src/main/java/gyro/aws/cloudfront/CloudFrontViewerCertificate.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontViewerCertificate.java
@@ -19,7 +19,7 @@ public class CloudFrontViewerCertificate extends Diffable implements Copyable<Vi
     @Updatable
     public Boolean getCloudfrontDefaultCertificate() {
         if (cloudfrontDefaultCertificate == null) {
-            cloudfrontDefaultCertificate = true;
+            cloudfrontDefaultCertificate = acmCertificateArn == null && iamCertificateId == null;
         }
 
         return cloudfrontDefaultCertificate;


### PR DESCRIPTION
If the user defines an acm/iam cert then cloudfront default certifcation should be false otherwise AWS throws an error about only providing one cert.