### PR TITLE
GYRO-405: Fix InstanceVolumeAttachmentResource fails to refresh if instance is gone.

### DIFF
--- a/src/main/java/gyro/aws/ec2/InstanceVolumeAttachmentResource.java
+++ b/src/main/java/gyro/aws/ec2/InstanceVolumeAttachmentResource.java
@@ -77,11 +77,7 @@ public class InstanceVolumeAttachmentResource extends AwsResource {
             .filter(o -> o.deviceName().equals(getDeviceName()) && o.ebs().volumeId().equals(getVolume().getId()))
             .findFirst().orElse(null);
 
-        if (blockDeviceMapping == null) {
-            return false;
-        }
-
-        return true;
+        return blockDeviceMapping != null;
     }
 
     @Override


### PR DESCRIPTION
Fix null point exception when refreshing instance volume resource when the instance has been terminated from the console.