### PR TITLE
GYRO-424: Don't require security group

### DIFF
--- a/src/main/java/gyro/aws/ec2/InstanceResource.java
+++ b/src/main/java/gyro/aws/ec2/InstanceResource.java
@@ -738,10 +738,6 @@ public class InstanceResource extends Ec2TaggableResource<Instance> implements G
             errors.add(new ValidationError(this, "instance-type", "The value - (" + getInstanceType() + ") is invalid for parameter 'instance-type'"));
         }
 
-        if (getLaunchTemplate() == null && getSecurityGroups().isEmpty()) {
-            errors.add(new ValidationError(this, "security-groups", "At least one 'security-group' is required."));
-        }
-
         if (!getCapacityReservation().equalsIgnoreCase("none")
             && !getCapacityReservation().equalsIgnoreCase("open")
             && !getCapacityReservation().startsWith("cr-")) {


### PR DESCRIPTION
This should automatically default to the "default" security group for accounts with a default vpc.