### PR TITLE
Fixes #160: Changing subnets in ASG breaks the update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,5 @@ ISSUES FIXED:
 
 * [158](https://github.com/perfectsense/gyro-aws-provider/issues/158): Add tags support to Classic ELB.
 * [159](https://github.com/perfectsense/gyro-aws-provider/issues/159): Route53 alias and geo-location should be complex types.
+* [160](https://github.com/perfectsense/gyro-aws-provider/issues/160): Changing subnets in ASG breaks the update.
 * [182](https://github.com/perfectsense/gyro-aws-provider/issues/182): cloudwatch/EventRuleResource, ec2/NetworkInterfaceResource and ec2/RouteTableResource don't generate example docs.

--- a/src/main/java/gyro/aws/autoscaling/AutoScalingGroupResource.java
+++ b/src/main/java/gyro/aws/autoscaling/AutoScalingGroupResource.java
@@ -650,11 +650,16 @@ public class AutoScalingGroupResource extends AwsResource implements GyroInstanc
         }
 
         boolean isDesiredCapacitySet = getDesiredCapacity() != null;
+        boolean isAvailabilityZoneSet = !getAvailabilityZones().isEmpty();
 
         copyFrom(autoScalingGroup);
 
         if (!isDesiredCapacitySet) {
             setDesiredCapacity(null);
+        }
+
+        if (!isAvailabilityZoneSet) {
+            setAvailabilityZones(null);
         }
 
         return true;


### PR DESCRIPTION
Updating subnet throws an error if availability zone is not set and the updated subnet's availability zone is different than the previously configured subnet's availability zone.

The reason for this was that the availability zone was saved in state even if not configured.

This fixes it by only setting the availability zone if configured.