### PR TITLE
Allow update of CloudFront Origins without workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@ ISSUES FIXED:
 * [160](https://github.com/perfectsense/gyro-aws-provider/issues/160): Changing subnets in ASG breaks the update.
 * [182](https://github.com/perfectsense/gyro-aws-provider/issues/182): cloudwatch/EventRuleResource, ec2/NetworkInterfaceResource and ec2/RouteTableResource don't generate example docs.
 * [187](https://github.com/perfectsense/gyro-aws-provider/issues/187): Add copyright license to java and gradle files.
+* [193](https://github.com/perfectsense/gyro-aws-provider/issues/193): Allow updates to CloudFront Origin

--- a/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
@@ -341,6 +341,7 @@ public class CloudFrontResource extends AwsResource implements Copyable<Distribu
      *
      * @subresource gyro.aws.cloudfront.CloudFrontOrigin
      */
+    @Updatable
     public Set<CloudFrontOrigin> getOrigin() {
         if (origin == null) {
             origin = new HashSet<>();


### PR DESCRIPTION
Fixes #193: 

Origin domains can be updated occasionally. This should not require a specific workflow.