### PR TITLE
Add primary key.

### DIFF
--- a/src/main/java/gyro/aws/autoscaling/AutoScalingPolicyStepAdjustment.java
+++ b/src/main/java/gyro/aws/autoscaling/AutoScalingPolicyStepAdjustment.java
@@ -72,4 +72,12 @@ public class AutoScalingPolicyStepAdjustment extends Diffable implements Copyabl
             .metricIntervalUpperBound(getMetricIntervalUpperBound())
             .build();
     }
+
+    @Override
+    public String primaryKey() {
+        return String.format("adjustment - %s; lower-bound - %s; upper-bound - %s",
+            getScalingAdjustment() != null ? getScalingAdjustment() : "",
+            getMetricIntervalLowerBound() != null ? getMetricIntervalLowerBound() : "",
+            getMetricIntervalUpperBound() != null ? getMetricIntervalUpperBound() : "");
+    }
 }


### PR DESCRIPTION
Fixes [GYRO-213](https://github.com/perfectsense/gyro/issues/213)
Add explicit primary key to all diffable type classes, as part of making primaryKey() abstract.