### PR TITLE
Break security group rules out into a separate resource

### DIFF
--- a/examples/.gyro/init.gyro
+++ b/examples/.gyro/init.gyro
@@ -1,4 +1,4 @@
 @highlander: true
 @repository: 'https://artifactory.psdops.com/public'
 @repository: 'https://artifactory.psdops.com/gyro-snapshots'
-@plugin: 'gyro:gyro-aws-provider:0.99.0-SNAPSHOT'
+@plugin: 'gyro:gyro-aws-provider:0.99.1-SNAPSHOT'

--- a/examples/autoscaling/autoscaling-group.gyro
+++ b/examples/autoscaling/autoscaling-group.gyro
@@ -35,33 +35,14 @@ aws::security-group security-group-auto-scaling-group-example-1
     name: "security-group-auto-scaling-group-example-1"
     vpc: $(aws::vpc vpc-auto-scaling-group-example)
     description: "security group instance example 1"
-    keep-default-egress-rules: true
-
-    ingress
-        description: "allow inbound http traffic, ipv4 only"
-        cidr-block: "0.0.0.0/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
-
-    egress
-        description: "allow outbound http traffic, ipv6 only"
-        ipv6-cidr-block: "::/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
 
     tags: {
         Name: "security-group-auto-scaling-group-example-1"
     }
 end
 
-aws::security-group security-group-auto-scaling-group-example-2
-    name: "security-group-auto-scaling-group-example-2"
-    vpc: $(aws::vpc vpc-auto-scaling-group-example)
-    description: "security group instance example 2"
+aws::security-group-rules security-group-auto-scaling-group-example-1-rules
+    security-group: $(aws::security-group security-group-auto-scaling-group-example-1)
     keep-default-egress-rules: true
 
     ingress
@@ -79,10 +60,37 @@ aws::security-group security-group-auto-scaling-group-example-2
         from-port: 22
         to-port: 22
     end
+end
+
+aws::security-group security-group-auto-scaling-group-example-2
+    name: "security-group-auto-scaling-group-example-2"
+    vpc: $(aws::vpc vpc-auto-scaling-group-example)
+    description: "security group instance example 2"
 
     tags: {
         Name: "security-group-auto-scaling-group-example-2"
     }
+end
+
+aws::security-group-rules security-group-auto-scaling-group-example-2-rules
+    security-group: $(aws::security-group security-group-auto-scaling-group-example-2)
+    keep-default-egress-rules: true
+
+    ingress
+        description: "allow inbound http traffic, ipv4 only"
+        cidr-block: "0.0.0.0/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
+
+    egress
+        description: "allow outbound http traffic, ipv6 only"
+        ipv6-cidr-block: "::/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
 end
 
 aws::launch-template launch-template-auto-scaling-group-example

--- a/examples/autoscaling/launch-configuration.gyro
+++ b/examples/autoscaling/launch-configuration.gyro
@@ -22,33 +22,14 @@ aws::security-group security-group-launch-configuration-example-1
     name: "security-group-launch-configuration-example-1"
     vpc: $(aws::vpc vpc-launch-configuration-example)
     description: "security group launch-configuration example 1"
-    keep-default-egress-rules: true
-
-    ingress
-        description: "allow inbound http traffic, ipv4 only"
-        cidr-block: "0.0.0.0/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
-
-    egress
-        description: "allow outbound http traffic, ipv6 only"
-        ipv6-cidr-block: "::/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
 
     tags: {
         Name: "security-group-launch-configuration-example-1"
     }
 end
 
-aws::security-group security-group-launch-configuration-example-2
-    name: "security-group-launch-configuration-example-2"
-    vpc: $(aws::vpc vpc-launch-configuration-example)
-    description: "security group launch-configuration example 2"
+aws::security-group-rules security-group-launch-configuration-example-1-rules
+    security-group: $(aws::security-group security-group-launch-configuration-example-1)
     keep-default-egress-rules: true
 
     ingress
@@ -66,10 +47,37 @@ aws::security-group security-group-launch-configuration-example-2
         from-port: 22
         to-port: 22
     end
+end
+
+aws::security-group security-group-launch-configuration-example-2
+    name: "security-group-launch-configuration-example-2"
+    vpc: $(aws::vpc vpc-launch-configuration-example)
+    description: "security group launch-configuration example 2"
 
     tags: {
         Name: "security-group-launch-configuration-example-2"
     }
+end
+
+aws::security-group-rules security-group-launch-configuration-example-2-rules
+    security-group: $(aws::security-group security-group-launch-configuration-example-2)
+    keep-default-egress-rules: true
+
+    ingress
+        description: "allow inbound http traffic, ipv4 only"
+        cidr-block: "0.0.0.0/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
+
+    egress
+        description: "allow outbound http traffic, ipv6 only"
+        ipv6-cidr-block: "::/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
 end
 
 aws::launch-configuration launch-configuration-1

--- a/examples/docdb/db-instance.gyro
+++ b/examples/docdb/db-instance.gyro
@@ -11,25 +11,14 @@ aws::security-group security-group-db-instance-example-1
     name: "db-instance-example-1"
     vpc: $(aws::vpc vpc-db-instance-example)
     description: "db-instance-example-1"
-    keep-default-egress-rules: true
-
-    ingress
-        description: "allow inbound ssh traffic, ipv4 only"
-        cidr-block: "0.0.0.0/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
 
     tags: {
         Name: "db-instance-example-1"
     }
 end
 
-aws::security-group security-group-db-instance-example-2
-    name: "db-instance-example-2"
-    vpc: $(aws::vpc vpc-db-instance-example)
-    description: "db-instance-example-2"
+aws::security-group-rules security-group-db-instance-example-1-rule
+    security-group: $(aws::security-group security-group-db-instance-example-1)
     keep-default-egress-rules: true
 
     ingress
@@ -39,10 +28,29 @@ aws::security-group security-group-db-instance-example-2
         from-port: 22
         to-port: 22
     end
+end
+
+aws::security-group security-group-db-instance-example-2
+    name: "db-instance-example-2"
+    vpc: $(aws::vpc vpc-db-instance-example)
+    description: "db-instance-example-2"
 
     tags: {
         Name: "db-instance-example-2"
     }
+end
+
+aws::security-group-rules security-group-db-instance-example-2-rules
+    security-group: $(aws::security-group security-group-db-instance-example-2)
+    keep-default-egress-rules: true
+
+    ingress
+        description: "allow inbound ssh traffic, ipv4 only"
+        cidr-block: "0.0.0.0/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
 end
 
 aws::subnet subnet-db-instance-example-1

--- a/examples/ec2/ami.gyro
+++ b/examples/ec2/ami.gyro
@@ -22,6 +22,14 @@ aws::security-group security-group
     name: "instance-example"
     vpc: $(aws::vpc vpc)
     description: "instance example"
+
+    tags: {
+        Name: "security group ami example"
+    }
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     ingress
@@ -31,10 +39,6 @@ aws::security-group security-group
         from-port: 22
         to-port: 22
     end
-
-    tags: {
-        Name: "security group ami example"
-    }
 end
 
 aws::key-pair key-pair-example
@@ -80,7 +84,7 @@ end
 aws::instance-volume-attachment volume-attachment
     device-name: "/dev/sde"
     volume: $(aws::ebs-volume volume)
-    instance: $(aws::instance instance-example)
+    instance: $(aws::instance instance-example-source)
 end
 
 aws::ami ami-example

--- a/examples/ec2/elastic-ip.gyro
+++ b/examples/ec2/elastic-ip.gyro
@@ -59,6 +59,14 @@ aws::security-group security-group-elastic-ip
     name: "instance-example"
     vpc: $(aws::vpc vpc-elastic-ip)
     description: "instance example"
+
+    tags: {
+        Name: "security group example elastic ip"
+    }
+end
+
+aws::security-group-rules security-group-elastic-ip-rules
+    security-group: $(aws::security-group security-group-elastic-ip)
     keep-default-egress-rules: true
 
     ingress
@@ -68,10 +76,6 @@ aws::security-group security-group-elastic-ip
         from-port: 22
         to-port: 22
     end
-
-    tags: {
-        Name: "security group example elastic ip"
-    }
 end
 
 aws::instance instance-example-elastic-ip

--- a/examples/ec2/instance.gyro
+++ b/examples/ec2/instance.gyro
@@ -22,6 +22,14 @@ aws::security-group security-group
     name: "instance-example"
     vpc: $(aws::vpc vpc)
     description: "instance example"
+
+    tags: {
+        Name: "security group instance example"
+    }
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     ingress
@@ -31,10 +39,6 @@ aws::security-group security-group
         from-port: 22
         to-port: 22
     end
-
-    tags: {
-        Name: "security group instance example"
-    }
 end
 
 aws::key-pair key-pair-example

--- a/examples/ec2/launch-template.gyro
+++ b/examples/ec2/launch-template.gyro
@@ -22,33 +22,14 @@ aws::security-group security-group-launch-template-example-1
     name: "security-group-launch-template-example-1"
     vpc: $(aws::vpc vpc-launch-template-example)
     description: "security group launch-template example 1"
-    keep-default-egress-rules: true
-
-    ingress
-        description: "allow inbound http traffic, ipv4 only"
-        cidr-block: "0.0.0.0/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
-
-    egress
-        description: "allow outbound http traffic, ipv6 only"
-        ipv6-cidr-block: "::/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
 
     tags: {
         Name: "security-group-launch-template-example-1"
     }
 end
 
-aws::security-group security-group-launch-template-example-2
-    name: "security-group-launch-template-example-2"
-    vpc: $(aws::vpc vpc-launch-template-example)
-    description: "security group launch-template example 2"
+aws::security-group-rules security-group-launch-template-example-1-rules
+    security-group: $(aws::security-group security-group-launch-template-example-1)
     keep-default-egress-rules: true
 
     ingress
@@ -66,10 +47,37 @@ aws::security-group security-group-launch-template-example-2
         from-port: 22
         to-port: 22
     end
+end
+
+aws::security-group security-group-launch-template-example-2
+    name: "security-group-launch-template-example-2"
+    vpc: $(aws::vpc vpc-launch-template-example)
+    description: "security group launch-template example 2"
 
     tags: {
         Name: "security-group-launch-template-example-2"
     }
+end
+
+aws::security-group-rules security-group-launch-template-example-2-rules
+    security-group: $(aws::security-group security-group-launch-template-example-2)
+    keep-default-egress-rules: true
+
+    ingress
+        description: "allow inbound http traffic, ipv4 only"
+        cidr-block: "0.0.0.0/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
+
+    egress
+        description: "allow outbound http traffic, ipv6 only"
+        ipv6-cidr-block: "::/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
 end
 
 aws::network-interface nic-example-launch-template-1

--- a/examples/ec2/network-interface.gyro
+++ b/examples/ec2/network-interface.gyro
@@ -21,6 +21,10 @@ aws::security-group nic-security-group-example
     name: "$(project) $(environment) - Allow web traffic only"
     vpc: $(aws::vpc vpc)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules nic-security-group-example-rules
+    security-group: $(aws::security-group nic-security-group-example)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']

--- a/examples/ec2/route-table-instance-gateway.gyro
+++ b/examples/ec2/route-table-instance-gateway.gyro
@@ -22,6 +22,14 @@ aws::security-group security-group
     name: "instance-example"
     vpc: $(aws::vpc vpc)
     description: "instance example"
+
+    tags: {
+        Name: "instance example"
+    }
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     ingress
@@ -31,10 +39,6 @@ aws::security-group security-group
         from-port: 22
         to-port: 22
     end
-
-    tags: {
-        Name: "instance example"
-    }
 end
 
 workflow 'replace-gateway'
@@ -62,8 +66,8 @@ aws::instance instance-example
     shutdown-behavior: "STOP"
     instance-type: "t2.micro"
     key: "example"
-    subnet-id: $(aws::subnet subnet).id
-    security-group-ids: $(aws::security-group security-group).*.id
+    subnet: $(aws::subnet subnet)
+    security-groups: $(aws::security-group security-group)
     disable-api-termination: false
     ebs-optimized: false
     source-dest-check: true

--- a/examples/ec2/security-group-rules.gyro
+++ b/examples/ec2/security-group-rules.gyro
@@ -1,0 +1,32 @@
+aws::vpc vpc-security-group-rule-example
+    cidr-block: "10.0.0.0/16"
+    provide-ipv6-cidr-block: true
+
+    tags: {
+        Name: "vpc-security-group-rule-example"
+    }
+end
+
+aws::security-group backend
+    vpc: $(aws::vpc vpc-security-group-rule-example)
+    name: "backend"
+    description: "backend"
+end
+
+aws::security-group master
+    vpc: $(aws::vpc vpc-security-group-rule-example)
+    name: "master"
+    description: "master"
+end
+
+aws::security-group-rules backend
+    security-group: $(aws::security-group backend)
+    ingress
+        protocol: -1
+        security-group: $SELF.security-group
+    end
+    ingress
+        protocol: -1
+        security-group: $(aws::security-group master)
+    end
+end

--- a/examples/ec2/security-group.gyro
+++ b/examples/ec2/security-group.gyro
@@ -11,6 +11,10 @@ aws::security-group security-group-example
     name: "$(project) $(environment) - Allow web traffic only"
     vpc: $(aws::vpc vpc-security-group-example)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-example-rules
+    security-group: $(aws::security-group security-group-example)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https', 999, 'foo']
@@ -36,6 +40,10 @@ aws::security-group security-group
     name: "security-group-reference-example"
     vpc: $(aws::vpc vpc-security-group-example)
     description: "Allow sg reference"
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     ingress
         description: "allow inbound from another sg"
         security-group: $(aws::security-group security-group-example)
@@ -68,6 +76,10 @@ aws::security-group security-group-peer
     name: "security-group-peer"
     vpc: $(aws::vpc vpc-peer)
     description: "Allow ipv6 outbound"
+end
+
+aws::security-group-rules security-group-peer-rules
+    security-group: $(aws::security-group security-group-peer)
     egress
         description: "allow outbound http traffic, ipv6 only"
         ipv6-cidr-block: "::/0"

--- a/examples/ec2/vpc-endpoint.gyro
+++ b/examples/ec2/vpc-endpoint.gyro
@@ -139,6 +139,10 @@ aws::security-group security-group-example-for-endpoint-1
     name: "$(project) $(environment) - Allow web traffic only example-for-endpoint-1"
     vpc: $(aws::vpc vpc-example-for-endpoint)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-example-for-endpoint-1-rules
+    security-group: $(aws::security-group security-group-example-for-endpoint-1)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']
@@ -164,6 +168,10 @@ aws::security-group security-group-example-for-endpoint-2
     name: "$(project) $(environment) - Allow web traffic only example-for-endpoint-2"
     vpc: $(aws::vpc vpc-example-for-endpoint)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-example-for-endpoint-2-rules
+    security-group: $(aws::security-group security-group-example-for-endpoint-2)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']
@@ -189,6 +197,10 @@ aws::security-group security-group-example-for-endpoint-3
     name: "$(project) $(environment) - Allow web traffic only example-for-endpoint-3"
     vpc: $(aws::vpc vpc-example-for-endpoint)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-example-for-endpoint-3-rules
+    security-group: $(aws::security-group security-group-example-for-endpoint-3)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']

--- a/examples/elasticache/cache-cluster.gyro
+++ b/examples/elasticache/cache-cluster.gyro
@@ -41,33 +41,14 @@ aws::security-group security-group-cache-cluster-example-1
     name: "security-group-cache-cluster-example-1"
     vpc: $(aws::vpc vpc-cache-cluster-example)
     description: "security group instance example 1"
-    keep-default-egress-rules: true
-
-    ingress
-        description: "allow inbound http traffic, ipv4 only"
-        cidr-block: "0.0.0.0/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
-
-    egress
-        description: "allow outbound http traffic, ipv6 only"
-        ipv6-cidr-block: "::/0"
-        protocol: "TCP"
-        from-port: 22
-        to-port: 22
-    end
 
     tags: {
         Name: "security-group-cache-cluster-example-1"
     }
 end
 
-aws::security-group security-group-cache-cluster-example-2
-    name: "security-group-cache-cluster-example-2"
-    vpc: $(aws::vpc vpc-cache-cluster-example)
-    description: "security group instance example 2"
+aws::security-group-rules security-group-cache-cluster-example-1-rules
+    security-group: $(aws::security-group security-group-cache-cluster-example-1)
     keep-default-egress-rules: true
 
     ingress
@@ -85,10 +66,37 @@ aws::security-group security-group-cache-cluster-example-2
         from-port: 22
         to-port: 22
     end
+end
+
+aws::security-group security-group-cache-cluster-example-2
+    name: "security-group-cache-cluster-example-2"
+    vpc: $(aws::vpc vpc-cache-cluster-example)
+    description: "security group instance example 2"
 
     tags: {
         Name: "security-group-cache-cluster-example-2"
     }
+end
+
+aws::security-group-rules security-group-cache-cluster-example-2-rules
+    security-group: $(aws::security-group security-group-cache-cluster-example-2)
+    keep-default-egress-rules: true
+
+    ingress
+        description: "allow inbound http traffic, ipv4 only"
+        cidr-block: "0.0.0.0/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
+
+    egress
+        description: "allow outbound http traffic, ipv6 only"
+        ipv6-cidr-block: "::/0"
+        protocol: "TCP"
+        from-port: 22
+        to-port: 22
+    end
 end
 
 aws::elasticache-subnet-group cache-subnet-group-cache-cluster-example

--- a/examples/elb/elb.gyro
+++ b/examples/elb/elb.gyro
@@ -104,6 +104,10 @@ aws::security-group security-group
     name: "elb example - allow web traffic"
     vpc: $(aws::vpc vpc)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']

--- a/examples/elbv2/alb.gyro
+++ b/examples/elbv2/alb.gyro
@@ -52,6 +52,10 @@ aws::security-group security-group
     name: "alb example - allow web traffic"
     vpc: $(aws::vpc vpc)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']
@@ -69,6 +73,10 @@ aws::security-group other-security-group
     name: "alb example - other - allow web traffic"
     vpc: $(aws::vpc vpc)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules other-security-group-rules
+    security-group: $(aws::security-group other-security-group)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']

--- a/examples/elbv2/nlb.gyro
+++ b/examples/elbv2/nlb.gyro
@@ -133,6 +133,10 @@ aws::security-group security-group
     name: "nlb example - allow web traffic"
     vpc: $(aws::vpc vpc)
     description: "Allow web traffic only"
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     @for port, type -in [80, 'http', 443, 'https']

--- a/examples/route53/record-from-instance.gyro
+++ b/examples/route53/record-from-instance.gyro
@@ -29,6 +29,14 @@ aws::security-group security-group
     name: "instance-example"
     vpc: $(aws::vpc vpc)
     description: "instance example"
+
+    tags: {
+        Name: "record-from-instance"
+    }
+end
+
+aws::security-group-rules security-group-rules
+    security-group: $(aws::security-group security-group)
     keep-default-egress-rules: true
 
     ingress
@@ -38,10 +46,6 @@ aws::security-group security-group
         from-port: 22
         to-port: 22
     end
-
-    tags: {
-        Name: "record-from-instance"
-    }
 end
 
 aws::instance instance

--- a/src/main/java/gyro/aws/ec2/SecurityGroupResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupResource.java
@@ -16,31 +16,24 @@
 
 package gyro.aws.ec2;
 
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
 import com.psddev.dari.util.ObjectUtils;
 import gyro.aws.AwsResource;
 import gyro.aws.Copyable;
 import gyro.core.GyroException;
 import gyro.core.GyroUI;
+import gyro.core.Type;
 import gyro.core.Wait;
 import gyro.core.resource.Id;
-import gyro.core.resource.Updatable;
-import gyro.core.Type;
 import gyro.core.resource.Output;
 import gyro.core.scope.State;
 import software.amazon.awssdk.services.ec2.Ec2Client;
 import software.amazon.awssdk.services.ec2.model.CreateSecurityGroupResponse;
 import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
 import software.amazon.awssdk.services.ec2.model.Ec2Exception;
-import software.amazon.awssdk.services.ec2.model.IpPermission;
-import software.amazon.awssdk.services.ec2.model.IpRange;
-import software.amazon.awssdk.services.ec2.model.Ipv6Range;
 import software.amazon.awssdk.services.ec2.model.SecurityGroup;
-import software.amazon.awssdk.services.ec2.model.UserIdGroupPair;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Create a security group with specified rules.
@@ -70,9 +63,6 @@ public class SecurityGroupResource extends Ec2TaggableResource<SecurityGroup> im
     private String name;
     private VpcResource vpc;
     private String description;
-    private List<SecurityGroupIngressRuleResource> ingress;
-    private List<SecurityGroupEgressRuleResource> egress;
-    private Boolean keepDefaultEgressRules;
 
     // Read-only
     private String id;
@@ -112,56 +102,6 @@ public class SecurityGroupResource extends Ec2TaggableResource<SecurityGroup> im
     }
 
     /**
-     * A list of ingress rules to block inbound traffic.
-     *
-     * @subresource gyro.aws.ec2.SecurityGroupIngressRuleResource
-     */
-    public List<SecurityGroupIngressRuleResource> getIngress() {
-        if (ingress == null) {
-            ingress = new ArrayList<>();
-        }
-
-        return ingress;
-    }
-
-    public void setIngress(List<SecurityGroupIngressRuleResource> ingress) {
-        this.ingress = ingress;
-    }
-
-    /**
-     * A list of egress rules to block outbound traffic.
-     *
-     * @subresource gyro.aws.ec2.SecurityGroupEgressRuleResource
-     */
-    public List<SecurityGroupEgressRuleResource> getEgress() {
-        if (egress == null) {
-            egress = new ArrayList<>();
-        }
-
-        return egress;
-    }
-
-    public void setEgress(List<SecurityGroupEgressRuleResource> egress) {
-        this.egress = egress;
-    }
-
-    /**
-     * Whether to keep the default egress rule. If false, the rule will be deleted.
-     */
-    @Updatable
-    public boolean isKeepDefaultEgressRules() {
-        if (keepDefaultEgressRules == null) {
-            keepDefaultEgressRules = true;
-        }
-
-        return keepDefaultEgressRules;
-    }
-
-    public void setKeepDefaultEgressRules(boolean keepDefaultEgressRules) {
-        this.keepDefaultEgressRules = keepDefaultEgressRules;
-    }
-
-    /**
      * The ID of the Security Group.
      */
     @Id
@@ -198,68 +138,6 @@ public class SecurityGroupResource extends Ec2TaggableResource<SecurityGroup> im
         setOwnerId(group.ownerId());
         setDescription(group.description());
 
-        getEgress().clear();
-        for (IpPermission permission : group.ipPermissionsEgress()) {
-            for (IpRange ipRange : permission.ipRanges()) {
-                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIp().equals("0.0.0.0/0")) {
-                    continue;
-                }
-
-                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setCidrBlock(ipRange.cidrIp());
-                rule.setDescription(ipRange.description());
-                getEgress().add(rule);
-            }
-
-            for (Ipv6Range ipRange : permission.ipv6Ranges()) {
-                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIpv6().equals("::/0")) {
-                    continue;
-                }
-
-                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setIpv6CidrBlock(ipRange.cidrIpv6());
-                rule.setDescription(ipRange.description());
-                getEgress().add(rule);
-            }
-
-            for (UserIdGroupPair groupPair : permission.userIdGroupPairs()) {
-                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setSecurityGroup(findById(SecurityGroupResource.class, groupPair.groupId()));
-                rule.setDescription(groupPair.description());
-                getEgress().add(rule);
-            }
-        }
-
-        getIngress().clear();
-        for (IpPermission permission : group.ipPermissions()) {
-            for (IpRange ipRange : permission.ipRanges()) {
-                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setCidrBlock(ipRange.cidrIp());
-                rule.setDescription(ipRange.description());
-                getIngress().add(rule);
-            }
-
-            for (Ipv6Range ipRange : permission.ipv6Ranges()) {
-                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setIpv6CidrBlock(ipRange.cidrIpv6());
-                rule.setDescription(ipRange.description());
-                getIngress().add(rule);
-            }
-
-            for (UserIdGroupPair groupPair : permission.userIdGroupPairs()) {
-                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
-                rule.copyPortProtocol(permission);
-                rule.setSecurityGroup(findById(SecurityGroupResource.class, groupPair.groupId()));
-                rule.setDescription(groupPair.description());
-                getIngress().add(rule);
-            }
-        }
-
         refreshTags();
     }
 
@@ -287,23 +165,10 @@ public class SecurityGroupResource extends Ec2TaggableResource<SecurityGroup> im
         );
 
         setId(response.groupId());
-
-        if (!isKeepDefaultEgressRules()) {
-            deleteDefaultEgressRule(client);
-        }
     }
 
     @Override
     protected void doUpdate(GyroUI ui, State state, AwsResource config, Set<String> changedProperties) {
-        SecurityGroupResource current = (SecurityGroupResource) config;
-
-        if (!current.isKeepDefaultEgressRules() && isKeepDefaultEgressRules()) {
-            throw new GyroException("Default rule removed. Cannot be undone.");
-        }
-
-        if (current.isKeepDefaultEgressRules() && !isKeepDefaultEgressRules()) {
-            deleteDefaultEgressRule(createClient(Ec2Client.class));
-        }
     }
 
     @Override
@@ -359,33 +224,5 @@ public class SecurityGroupResource extends Ec2TaggableResource<SecurityGroup> im
         }
 
         return securityGroup;
-    }
-
-    private void deleteDefaultEgressRule(Ec2Client client) {
-        SecurityGroup group = getSecurityGroup(client);
-
-        IpPermission permission = group.ipPermissionsEgress().stream()
-            .filter(o -> o.ipProtocol().equals("-1") && o.ipRanges().stream().anyMatch(oo -> oo.cidrIp().equals("0.0.0.0/0")))
-            .findFirst().orElse(null);
-
-        if (permission != null) {
-            SecurityGroupEgressRuleResource defaultRule = newSubresource(SecurityGroupEgressRuleResource.class);
-            defaultRule.copyPortProtocol(permission);
-            defaultRule.setDescription(permission.ipRanges().stream().filter(o -> o.cidrIp().equals("0.0.0.0/0")).findFirst().get().description());
-            defaultRule.setCidrBlock("0.0.0.0/0");
-            defaultRule.delete(client, getId());
-        }
-
-        IpPermission permissionIpv6 = group.ipPermissionsEgress().stream()
-            .filter(o -> o.ipProtocol().equals("-1") && o.ipv6Ranges().stream().anyMatch(oo -> oo.cidrIpv6().equals("::/0")))
-            .findFirst().orElse(null);
-
-        if (permissionIpv6 != null) {
-            SecurityGroupEgressRuleResource defaultRule = newSubresource(SecurityGroupEgressRuleResource.class);
-            defaultRule.copyPortProtocol(permissionIpv6);
-            defaultRule.setDescription(permissionIpv6.ipv6Ranges().stream().filter(o -> o.cidrIpv6().equals("::/0")).findFirst().get().description());
-            defaultRule.setIpv6CidrBlock("::/0");
-            defaultRule.delete(client, getId());
-        }
     }
 }

--- a/src/main/java/gyro/aws/ec2/SecurityGroupResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupResource.java
@@ -47,14 +47,6 @@ import software.amazon.awssdk.services.ec2.model.SecurityGroup;
  *         name: "security-group-example"
  *         vpc: $(aws::vpc vpc-security-group-example)
  *         description: "security group example"
- *
- *         ingress
- *             description: "allow inbound http traffic"
- *             cidr-block: "0.0.0.0/0"
- *             protocol: "TCP"
- *             from-port: 80
- *             to-port: 80
- *         end
  *     end
  */
 @Type("security-group")

--- a/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
@@ -111,7 +111,7 @@ public class SecurityGroupRulesResource extends AwsResource {
      * Whether to keep the default egress rule. If false, the rule will be deleted.
      */
     @Updatable
-    public Boolean isKeepDefaultEgressRules() {
+    public Boolean getKeepDefaultEgressRules() {
         if (keepDefaultEgressRules == null) {
             keepDefaultEgressRules = true;
         }
@@ -137,7 +137,7 @@ public class SecurityGroupRulesResource extends AwsResource {
         getEgress().clear();
         for (IpPermission permission : group.ipPermissionsEgress()) {
             for (IpRange ipRange : permission.ipRanges()) {
-                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIp()
+                if (getKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIp()
                     .equals("0.0.0.0/0")) {
                     continue;
                 }
@@ -150,7 +150,7 @@ public class SecurityGroupRulesResource extends AwsResource {
             }
 
             for (Ipv6Range ipRange : permission.ipv6Ranges()) {
-                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIpv6()
+                if (getKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIpv6()
                     .equals("::/0")) {
                     continue;
                 }
@@ -203,7 +203,7 @@ public class SecurityGroupRulesResource extends AwsResource {
     public void create(GyroUI ui, State state) throws Exception {
         Ec2Client client = createClient(Ec2Client.class);
 
-        if (!isKeepDefaultEgressRules()) {
+        if (!getKeepDefaultEgressRules()) {
             deleteDefaultEgressRule(client);
         }
     }
@@ -212,11 +212,11 @@ public class SecurityGroupRulesResource extends AwsResource {
     public void update(GyroUI ui, State state, Resource resource, Set<String> changedFieldNames) throws Exception {
         SecurityGroupRulesResource current = (SecurityGroupRulesResource) resource;
 
-        if (!current.isKeepDefaultEgressRules() && isKeepDefaultEgressRules()) {
+        if (!current.getKeepDefaultEgressRules() && getKeepDefaultEgressRules()) {
             throw new GyroException("Default rule removed. Cannot be undone.");
         }
 
-        if (current.isKeepDefaultEgressRules() && !isKeepDefaultEgressRules()) {
+        if (current.getKeepDefaultEgressRules() && !getKeepDefaultEgressRules()) {
             deleteDefaultEgressRule(createClient(Ec2Client.class));
         }
     }

--- a/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
@@ -22,6 +22,35 @@ import software.amazon.awssdk.services.ec2.model.Ipv6Range;
 import software.amazon.awssdk.services.ec2.model.SecurityGroup;
 import software.amazon.awssdk.services.ec2.model.UserIdGroupPair;
 
+/**
+ * Add ingress and egress rules to a security group.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *     aws::security-group backend
+ *         vpc: $(aws::vpc vpc)
+ *
+ *         name: "backend"
+ *         description: "backend"
+ *     end
+ *
+ *     aws::security-group-rules backend
+ *         security-group: $(aws::security-group backend)
+ *
+ *         ingress
+ *             protocol: -1
+ *             security-group: $SELF.security-group
+ *         end
+ *
+ *         ingress
+ *             protocol: -1
+ *             security-group: $(aws::security-group master)
+ *         end
+ *     end
+ */
 @Type("security-group-rules")
 public class SecurityGroupRulesResource extends AwsResource {
 

--- a/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
@@ -1,0 +1,270 @@
+package gyro.aws.ec2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.psddev.dari.util.ObjectUtils;
+import gyro.aws.AwsResource;
+import gyro.core.GyroException;
+import gyro.core.GyroUI;
+import gyro.core.Type;
+import gyro.core.resource.Resource;
+import gyro.core.resource.Updatable;
+import gyro.core.scope.State;
+import gyro.core.validation.Required;
+import software.amazon.awssdk.services.ec2.Ec2Client;
+import software.amazon.awssdk.services.ec2.model.DescribeSecurityGroupsResponse;
+import software.amazon.awssdk.services.ec2.model.Ec2Exception;
+import software.amazon.awssdk.services.ec2.model.IpPermission;
+import software.amazon.awssdk.services.ec2.model.IpRange;
+import software.amazon.awssdk.services.ec2.model.Ipv6Range;
+import software.amazon.awssdk.services.ec2.model.SecurityGroup;
+import software.amazon.awssdk.services.ec2.model.UserIdGroupPair;
+
+@Type("security-group-rules")
+public class SecurityGroupRulesResource extends AwsResource {
+
+    private SecurityGroupResource securityGroup;
+    private List<SecurityGroupIngressRuleResource> ingress;
+    private List<SecurityGroupEgressRuleResource> egress;
+    private Boolean keepDefaultEgressRules;
+
+    /**
+     * The security group to apply rules to.
+     */
+    @Required
+    public SecurityGroupResource getSecurityGroup() {
+        return securityGroup;
+    }
+
+    public void setSecurityGroup(SecurityGroupResource securityGroup) {
+        this.securityGroup = securityGroup;
+    }
+
+    /**
+     * A list of ingress rules to block inbound traffic.
+     *
+     * @subresource gyro.aws.ec2.SecurityGroupIngressRuleResource
+     */
+    @Updatable
+    public List<SecurityGroupIngressRuleResource> getIngress() {
+        if (ingress == null) {
+            ingress = new ArrayList<>();
+        }
+
+        return ingress;
+    }
+
+    public void setIngress(List<SecurityGroupIngressRuleResource> ingress) {
+        this.ingress = ingress;
+    }
+
+    /**
+     * A list of egress rules to block outbound traffic.
+     *
+     * @subresource gyro.aws.ec2.SecurityGroupEgressRuleResource
+     */
+    @Updatable
+    public List<SecurityGroupEgressRuleResource> getEgress() {
+        if (egress == null) {
+            egress = new ArrayList<>();
+        }
+
+        return egress;
+    }
+
+    public void setEgress(List<SecurityGroupEgressRuleResource> egress) {
+        this.egress = egress;
+    }
+
+    /**
+     * Whether to keep the default egress rule. If false, the rule will be deleted.
+     */
+    @Updatable
+    public Boolean isKeepDefaultEgressRules() {
+        if (keepDefaultEgressRules == null) {
+            keepDefaultEgressRules = true;
+        }
+
+        return keepDefaultEgressRules;
+    }
+
+    public void setKeepDefaultEgressRules(Boolean keepDefaultEgressRules) {
+        this.keepDefaultEgressRules = keepDefaultEgressRules;
+    }
+
+    @Override
+    public boolean refresh() {
+        Ec2Client client = createClient(Ec2Client.class);
+
+        SecurityGroup group = getSecurityGroup(client);
+        copyFrom(group);
+
+        return true;
+    }
+
+    public void copyFrom(SecurityGroup group) {
+        getEgress().clear();
+        for (IpPermission permission : group.ipPermissionsEgress()) {
+            for (IpRange ipRange : permission.ipRanges()) {
+                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIp()
+                    .equals("0.0.0.0/0")) {
+                    continue;
+                }
+
+                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setCidrBlock(ipRange.cidrIp());
+                rule.setDescription(ipRange.description());
+                getEgress().add(rule);
+            }
+
+            for (Ipv6Range ipRange : permission.ipv6Ranges()) {
+                if (isKeepDefaultEgressRules() && permission.ipProtocol().equals("-1") && ipRange.cidrIpv6()
+                    .equals("::/0")) {
+                    continue;
+                }
+
+                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setIpv6CidrBlock(ipRange.cidrIpv6());
+                rule.setDescription(ipRange.description());
+                getEgress().add(rule);
+            }
+
+            for (UserIdGroupPair groupPair : permission.userIdGroupPairs()) {
+                SecurityGroupEgressRuleResource rule = newSubresource(SecurityGroupEgressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setSecurityGroup(findById(SecurityGroupResource.class, groupPair.groupId()));
+                rule.setDescription(groupPair.description());
+                getEgress().add(rule);
+            }
+        }
+
+        getIngress().clear();
+        for (IpPermission permission : group.ipPermissions()) {
+            for (IpRange ipRange : permission.ipRanges()) {
+                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setCidrBlock(ipRange.cidrIp());
+                rule.setDescription(ipRange.description());
+                getIngress().add(rule);
+            }
+
+            for (Ipv6Range ipRange : permission.ipv6Ranges()) {
+                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setIpv6CidrBlock(ipRange.cidrIpv6());
+                rule.setDescription(ipRange.description());
+                getIngress().add(rule);
+            }
+
+            for (UserIdGroupPair groupPair : permission.userIdGroupPairs()) {
+                SecurityGroupIngressRuleResource rule = newSubresource(SecurityGroupIngressRuleResource.class);
+                rule.copyPortProtocol(permission);
+                rule.setSecurityGroup(findById(SecurityGroupResource.class, groupPair.groupId()));
+                rule.setDescription(groupPair.description());
+                getIngress().add(rule);
+            }
+        }
+    }
+
+    @Override
+    public void create(GyroUI ui, State state) throws Exception {
+        Ec2Client client = createClient(Ec2Client.class);
+
+        if (!isKeepDefaultEgressRules()) {
+            deleteDefaultEgressRule(client);
+        }
+    }
+
+    @Override
+    public void update(GyroUI ui, State state, Resource resource, Set<String> changedFieldNames) throws Exception {
+        SecurityGroupRulesResource current = (SecurityGroupRulesResource) resource;
+
+        if (!current.isKeepDefaultEgressRules() && isKeepDefaultEgressRules()) {
+            throw new GyroException("Default rule removed. Cannot be undone.");
+        }
+
+        if (current.isKeepDefaultEgressRules() && !isKeepDefaultEgressRules()) {
+            deleteDefaultEgressRule(createClient(Ec2Client.class));
+        }
+    }
+
+    @Override
+    public void delete(GyroUI ui, State state) throws Exception {
+
+    }
+
+    private SecurityGroup getSecurityGroup(Ec2Client client) {
+        SecurityGroup securityGroup = null;
+
+        if (ObjectUtils.isBlank(getSecurityGroup())) {
+            throw new GyroException("security group is missing");
+        }
+
+        try {
+            DescribeSecurityGroupsResponse response = client.describeSecurityGroups(
+                r -> r.filters(
+                    f -> f.name("group-id").values(getSecurityGroup().getId()),
+                    f -> f.name("vpc-id").values(getSecurityGroup().getVpc().getId())
+                )
+            );
+
+            if (!response.securityGroups().isEmpty()) {
+                securityGroup = response.securityGroups().get(0);
+            }
+
+        } catch (Ec2Exception ex) {
+            if (!ex.getLocalizedMessage().contains("does not exist")) {
+                throw ex;
+            }
+        }
+
+        return securityGroup;
+    }
+
+    private void deleteDefaultEgressRule(Ec2Client client) {
+        SecurityGroup group = getSecurityGroup(client);
+
+        IpPermission permission = group.ipPermissionsEgress().stream()
+            .filter(o -> o.ipProtocol().equals("-1") && o.ipRanges()
+                .stream()
+                .anyMatch(oo -> oo.cidrIp().equals("0.0.0.0/0")))
+            .findFirst().orElse(null);
+
+        if (permission != null) {
+            SecurityGroupEgressRuleResource defaultRule = newSubresource(SecurityGroupEgressRuleResource.class);
+            defaultRule.copyPortProtocol(permission);
+            defaultRule.setDescription(permission.ipRanges()
+                .stream()
+                .filter(o -> o.cidrIp().equals("0.0.0.0/0"))
+                .findFirst()
+                .get()
+                .description());
+            defaultRule.setCidrBlock("0.0.0.0/0");
+            defaultRule.delete(client, getSecurityGroup().getId());
+        }
+
+        IpPermission permissionIpv6 = group.ipPermissionsEgress().stream()
+            .filter(o -> o.ipProtocol().equals("-1") && o.ipv6Ranges()
+                .stream()
+                .anyMatch(oo -> oo.cidrIpv6().equals("::/0")))
+            .findFirst().orElse(null);
+
+        if (permissionIpv6 != null) {
+            SecurityGroupEgressRuleResource defaultRule = newSubresource(SecurityGroupEgressRuleResource.class);
+            defaultRule.copyPortProtocol(permissionIpv6);
+            defaultRule.setDescription(permissionIpv6.ipv6Ranges()
+                .stream()
+                .filter(o -> o.cidrIpv6().equals("::/0"))
+                .findFirst()
+                .get()
+                .description());
+            defaultRule.setIpv6CidrBlock("::/0");
+            defaultRule.delete(client, getSecurityGroup().getId());
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #200 

This allows security groups to have circular dependencies on each other.

```
aws::security-group backend
    vpc: $(aws::vpc vpc)

    name: "backend"
    description: "backend"

    tags: {
        "Name": "test"
    }
end

aws::security-group-rules backend
    security-group: $(aws::security-group backend)

    ingress
        protocol: -1
        security-group: $SELF.security-group
    end

    ingress
        protocol: -1
        security-group: $(aws::security-group master)
    end
end
```