### PR TITLE
Fix NPE when refreshing security group rules

### DIFF
--- a/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
+++ b/src/main/java/gyro/aws/ec2/SecurityGroupRulesResource.java
@@ -128,6 +128,10 @@ public class SecurityGroupRulesResource extends AwsResource {
         Ec2Client client = createClient(Ec2Client.class);
 
         SecurityGroup group = getSecurityGroup(client);
+        if (group == null) {
+            return false;
+        }
+
         copyFrom(group);
 
         return true;


### PR DESCRIPTION
If the security group is deleted in the console, the refresh will trigger a NPE