### PR TITLE
Implement DynamoDb lock backend

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
 
     implementation 'com.google.guava:guava:23.0'
     implementation 'com.psddev:dari-util:3.3.607-xe0f27a'
-    implementation enforcedPlatform('software.amazon.awssdk:bom:2.10.77')
+    implementation enforcedPlatform('software.amazon.awssdk:bom:2.13.1')
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'software.amazon.awssdk:autoscaling'
     implementation 'software.amazon.awssdk:cloudfront'
@@ -103,6 +103,7 @@ dependencies {
     implementation 'software.amazon.awssdk:docdb'
     implementation 'software.amazon.awssdk:acm'
     implementation 'software.amazon.awssdk:acmpca'
+    implementation 'software.amazon.awssdk:dynamodb'
     implementation 'org.json:json:20180813'
 
     gyroDoclet "gyro:gyro-doclet:0.99.0-SNAPSHOT"

--- a/src/main/java/gyro/aws/DynamoDbLockBackend.java
+++ b/src/main/java/gyro/aws/DynamoDbLockBackend.java
@@ -47,7 +47,7 @@ public class DynamoDbLockBackend extends LockBackend {
     }
 
     public String getLockKey() {
-        return lockKey != null ? lockKey : "GyroLockKey";
+        return lockKey != null ? lockKey : "default";
     }
 
     public void setLockKey(String lockKey) {

--- a/src/main/java/gyro/aws/DynamoDbLockBackend.java
+++ b/src/main/java/gyro/aws/DynamoDbLockBackend.java
@@ -20,6 +20,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import com.psddev.dari.util.ObjectUtils;
 import gyro.core.GyroException;
 import gyro.core.LockBackend;
 import gyro.core.Type;
@@ -37,6 +38,7 @@ public class DynamoDbLockBackend extends LockBackend {
 
     private String tableName;
     private String lockKey;
+    private String credentials;
 
     public String getTableName() {
         return tableName;
@@ -52,6 +54,18 @@ public class DynamoDbLockBackend extends LockBackend {
 
     public void setLockKey(String lockKey) {
         this.lockKey = lockKey;
+    }
+
+    public void setCredentials(String credentials) {
+        this.credentials = credentials;
+    }
+
+    public String getCredentials() {
+        if (ObjectUtils.isBlank(credentials)) {
+            setCredentials("default");
+        }
+
+        return credentials;
     }
 
     @Override
@@ -168,6 +182,6 @@ public class DynamoDbLockBackend extends LockBackend {
     private AwsCredentials credentials() {
         return (AwsCredentials) getRootScope().getSettings(CredentialsSettings.class)
             .getCredentialsByName()
-            .get("aws::default");
+            .get("aws::" + getCredentials());
     }
 }

--- a/src/main/java/gyro/aws/DynamoDbLockBackend.java
+++ b/src/main/java/gyro/aws/DynamoDbLockBackend.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.aws;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import gyro.core.GyroException;
+import gyro.core.LockBackend;
+import gyro.core.Type;
+import gyro.core.auth.CredentialsSettings;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException;
+import software.amazon.awssdk.services.dynamodb.model.DeleteItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.GetItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest;
+import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
+
+@Type("dynamo-db")
+public class DynamoDbLockBackend extends LockBackend {
+
+    private String tableName;
+    private String lockKey;
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public void setTableName(String tableName) {
+        this.tableName = tableName;
+    }
+
+    public String getLockKey() {
+        return lockKey != null ? lockKey : "GyroLockKey";
+    }
+
+    public void setLockKey(String lockKey) {
+        this.lockKey = lockKey;
+    }
+
+    @Override
+    public void lock(String lockId) throws Exception {
+        DynamoDbClient client = client();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("LockKey", AttributeValue.builder().s(getLockKey()).build());
+        item.put("GyroId", AttributeValue.builder().s(lockId).build());
+
+        PutItemRequest putItemRequest = PutItemRequest.builder()
+            .tableName(getTableName())
+            .item(item)
+            .conditionExpression("attribute_not_exists(LockKey)")
+            .build();
+
+        try {
+            client.putItem(putItemRequest);
+        } catch (ConditionalCheckFailedException ex) {
+            throw new GyroException(String.format("State is currently locked!%s", getCurrentLockIdString()));
+        }
+    }
+
+    @Override
+    public void unlock(String lockId) throws Exception {
+        DynamoDbClient client = client();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("LockKey", AttributeValue.builder().s(getLockKey()).build());
+
+        Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
+        expressionAttributeValues.put(":id", AttributeValue.builder().s(lockId).build());
+
+        DeleteItemRequest deleteItemRequest = DeleteItemRequest.builder()
+            .tableName(getTableName())
+            .key(item)
+            .conditionExpression("GyroId = :id")
+            .expressionAttributeValues(expressionAttributeValues)
+            .build();
+
+        try {
+            client.deleteItem(deleteItemRequest);
+
+        } catch (ConditionalCheckFailedException ex) {
+            throw new GyroException(String.format(
+                "Cannot unlock '%s' as it is no longer the active lock!%s", lockId, getCurrentLockIdString()));
+        }
+    }
+
+    @Override
+    public void updateLockInfo(String lockId, String info) throws Exception {
+        DynamoDbClient client = client();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("LockKey", AttributeValue.builder().s(getLockKey()).build());
+
+        Map<String, AttributeValue> expressionAttributeValues = new HashMap<>();
+        expressionAttributeValues.put(":id", AttributeValue.builder().s(lockId).build());
+        expressionAttributeValues.put(":info", AttributeValue.builder().s(info).build());
+
+        UpdateItemRequest updateItemRequest = UpdateItemRequest.builder()
+            .tableName(getTableName())
+            .key(item)
+            .conditionExpression("GyroId = :id")
+            .updateExpression("SET GyroLockInfo = :info")
+            .expressionAttributeValues(expressionAttributeValues)
+            .build();
+
+        try {
+            client.updateItem(updateItemRequest);
+
+        } catch (ConditionalCheckFailedException ex) {
+            throw new GyroException(String.format(
+                "Cannot update info for '%s' as it is no longer the active lock!%s",
+                lockId,
+                getCurrentLockIdString()));
+        }
+    }
+
+    private String getCurrentLockIdString() {
+        Optional<Map<String, AttributeValue>> currentLock = getCurrentLock();
+        return String.join(
+            "\n",
+            currentLock.map(this::getLockId).map(id -> String.format("\nCurrent lock ID: '%s'.", id)).orElse(""),
+            currentLock.map(this::getLockInfo).orElse(""));
+    }
+
+    private String getLockInfo(Map<String, AttributeValue> currentLock) {
+        return Optional.ofNullable(currentLock.get("GyroLockInfo")).map(AttributeValue::s).orElse(null);
+    }
+
+    private String getLockId(Map<String, AttributeValue> currentLock) {
+        return Optional.ofNullable(currentLock.get("GyroId")).map(AttributeValue::s).orElse(null);
+    }
+
+    private Optional<Map<String, AttributeValue>> getCurrentLock() {
+        DynamoDbClient client = client();
+
+        Map<String, AttributeValue> item = new HashMap<>();
+        item.put("LockKey", AttributeValue.builder().s(getLockKey()).build());
+
+        GetItemRequest getItemRequest = GetItemRequest.builder()
+            .tableName(getTableName())
+            .key(item)
+            .build();
+
+        return Optional.ofNullable(client.getItem(getItemRequest).item());
+    }
+
+    private DynamoDbClient client() {
+        return AwsResource.createClient(DynamoDbClient.class, credentials());
+    }
+
+    private AwsCredentials credentials() {
+        return (AwsCredentials) getRootScope().getSettings(CredentialsSettings.class)
+            .getCredentialsByName()
+            .get("aws::default");
+    }
+}


### PR DESCRIPTION
Fixes #232 

This PR uses DynamoDb as a locking backend by utilizing condition expressions to ensure there is only ever one lock at a time. There are a few steps required to use this. First, create a new DynamoDb table, and **make the primary key a string named** `LockKey`. Next, add the `@lock-backend` to your `init.gyro` like the following:
```
@lock-backend 'aws::dynamo-db'
    table-name: "lock-table-name"
    lock-key: "GyroProject1Lock"
@end
```
The two fields are `table-name` and `lock-key`. `table-name` is simply the name of the table that you created above. The `lock-key` field is only needed if this same table needs to be used by multiple projects (eg. a unique `lock-key` value in each `init.gyro` for each project). If it is not provided a default will be supplied.