### PR TITLE
Allow /16 through /32 IPv4 CIDR ranges for Classic WAF to be inline with AWS accepted values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ ISSUES FIXED:
 * [182](https://github.com/perfectsense/gyro-aws-provider/issues/182): cloudwatch/EventRuleResource, ec2/NetworkInterfaceResource and ec2/RouteTableResource don't generate example docs.
 * [187](https://github.com/perfectsense/gyro-aws-provider/issues/187): Add copyright license to java and gradle files.
 * [193](https://github.com/perfectsense/gyro-aws-provider/issues/193): Allow updates to CloudFront Origin
+* [254](https://github.com/perfectsense/gyro-aws-provider/issues/254): Allow /16 through /32 IPv4 CIDR ranges for Classic WAF

--- a/src/main/java/gyro/aws/waf/common/IpSetDescriptorResource.java
+++ b/src/main/java/gyro/aws/waf/common/IpSetDescriptorResource.java
@@ -127,9 +127,15 @@ public abstract class IpSetDescriptorResource extends AbstractWafResource implem
             isValid = false;
             String ip = cidr.split("/")[0];
             String range = cidr.split("/")[1];
+            int rangeInt = 0;
+            try {
+                rangeInt = Integer.parseInt(range);
+            } catch (NumberFormatException e) {
+                // fails anyway
+            }
 
             if (getType().equals("IPV4")) {
-                isValid = (range.equals("8") || range.equals("16") || range.equals("24") || range.equals("32"));
+                isValid = (range.equals("8") || (16 <= rangeInt && rangeInt <= 32));
             } else if (getType().equals("IPV6")) {
                 isValid = (range.equals("24") || range.equals("32")
                     || range.equals("48") || range.equals("56") || range.equals("64") || range.equals("128"));


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-aws-provider/issues/254

This PR allows CIDR ranges of /16 through /32 for Classic WAF IPv4 rule sets.