### PR TITLE
Fix aws::iam-policy refreshes older policy version

### DIFF
--- a/src/main/java/gyro/aws/iam/PolicyResource.java
+++ b/src/main/java/gyro/aws/iam/PolicyResource.java
@@ -160,7 +160,7 @@ public class PolicyResource extends AwsResource implements Copyable<Policy> {
         }
 
         GetPolicyVersionResponse versionResponse = client.getPolicyVersion(
-            r -> r.versionId(getPastVersionId())
+            r -> r.versionId(policy.defaultVersionId())
                 .policyArn(getArn())
         );
 


### PR DESCRIPTION
Fixes: #362 

When multiple versions are there for a policy, the policy json should be fetched of the version that is active, in this case that is the version that is labeled default.

The previous approach was to use the last version id, which is not always the default one and can cause an issue.