### PR TITLE
EKS Nodegroup deleted from console should be created instead of being replaced

### DIFF
--- a/src/main/java/gyro/aws/eks/EksNodegroupResource.java
+++ b/src/main/java/gyro/aws/eks/EksNodegroupResource.java
@@ -317,7 +317,7 @@ public class EksNodegroupResource extends AwsResource implements Copyable<Nodegr
 
         Nodegroup nodegroup = getNodegroup(client);
 
-        if (nodegroup == null) {
+        if (nodegroup == null || nodegroup.status().equals(NodegroupStatus.DELETING)) {
             return false;
         }
 


### PR DESCRIPTION
Fixes #359 