### PR TITLE
Gyro loses track of rds cluster parameter group if a parameter is incorrect

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterParameterGroupResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterParameterGroupResource.java
@@ -188,12 +188,14 @@ public class DbClusterParameterGroupResource extends RdsTaggableResource impleme
 
         setArn(response.dbClusterParameterGroup().dbClusterParameterGroupArn());
 
-        List<DbParameter> dbParameters = new ArrayList<>(getParameter());
-        getParameter().clear();
-        state.save();
-        setParameter(dbParameters);
+        if (!getParameter().isEmpty()) {
+            List<DbParameter> dbParameters = new ArrayList<>(getParameter());
+            getParameter().clear();
+            state.save();
+            setParameter(dbParameters);
 
-        modifyClusterParameterGroup();
+            modifyClusterParameterGroup();
+        }
     }
 
     @Override

--- a/src/main/java/gyro/aws/rds/DbClusterParameterGroupResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterParameterGroupResource.java
@@ -187,6 +187,12 @@ public class DbClusterParameterGroupResource extends RdsTaggableResource impleme
         );
 
         setArn(response.dbClusterParameterGroup().dbClusterParameterGroupArn());
+
+        List<DbParameter> dbParameters = new ArrayList<>(getParameter());
+        getParameter().clear();
+        state.save();
+        setParameter(dbParameters);
+
         modifyClusterParameterGroup();
     }
 

--- a/src/main/java/gyro/aws/rds/DbParameterGroupResource.java
+++ b/src/main/java/gyro/aws/rds/DbParameterGroupResource.java
@@ -190,6 +190,12 @@ public class DbParameterGroupResource extends RdsTaggableResource implements Cop
         );
 
         setArn(response.dbParameterGroup().dbParameterGroupArn());
+
+        List<DbParameter> dbParameters = new ArrayList<>(getParameter());
+        getParameter().clear();
+        state.save();
+        setParameter(dbParameters);
+
         modifyParameterGroup();
     }
 

--- a/src/main/java/gyro/aws/rds/DbParameterGroupResource.java
+++ b/src/main/java/gyro/aws/rds/DbParameterGroupResource.java
@@ -191,12 +191,14 @@ public class DbParameterGroupResource extends RdsTaggableResource implements Cop
 
         setArn(response.dbParameterGroup().dbParameterGroupArn());
 
-        List<DbParameter> dbParameters = new ArrayList<>(getParameter());
-        getParameter().clear();
-        state.save();
-        setParameter(dbParameters);
+        if (!getParameter().isEmpty()) {
+            List<DbParameter> dbParameters = new ArrayList<>(getParameter());
+            getParameter().clear();
+            state.save();
+            setParameter(dbParameters);
 
-        modifyParameterGroup();
+            modifyParameterGroup();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fixes #375 