### PR TITLE
Don't set finalDBSnapshotIdentifier and skipFinalSnapshot

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -851,7 +851,7 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
 
         client.deleteDBCluster(
             r -> r.dbClusterIdentifier(getIdentifier())
-                    .finalDBSnapshotIdentifier(getFinalDbSnapshotIdentifier())
+                    .finalDBSnapshotIdentifier(!getSkipFinalSnapshot() ? getFinalDbSnapshotIdentifier() : null)
                     .skipFinalSnapshot(getSkipFinalSnapshot())
         );
 


### PR DESCRIPTION
Fixes #423 

I think issue #423 was caused by getting into a bad state via a workflow. The fix was to flip the skip snapshot flag to true in state. That however caused a `You cannot specify both FinalDBSnapshotIdentifier and SkipFinalSnapshot` error. This PR now fixes that by ensuring that if skip snapshot flag is true then the final snapshot id is not set.