### PR TITLE
Implement Forward Action Resource to allow multiple target groups by Weight

### DIFF
--- a/examples/elbv2/alb.gyro
+++ b/examples/elbv2/alb.gyro
@@ -124,9 +124,13 @@ aws::application-load-balancer-listener listener-example
     end
 
     default-action
-        type: "forward"
-        target-group: $(aws::load-balancer-target-group target-group-example)
         order: 2
+        forward-action
+            target-weight
+                target-group: $(aws::load-balancer-target-group target-group-example)
+                weight: 1
+            end
+        end
     end
 end
 
@@ -157,7 +161,6 @@ aws::application-load-balancer-listener-rule listener-rule-example
     priority: "1"
 
     action
-        type: "fixed-response"
         order: 2
 
         fixed-response-action
@@ -167,7 +170,6 @@ aws::application-load-balancer-listener-rule listener-rule-example
         end
     end
     action
-        type: "authenticate-cognito"
         order: 1
 
         authenticate-cognito-action

--- a/examples/elbv2/alb.gyro
+++ b/examples/elbv2/alb.gyro
@@ -126,7 +126,7 @@ aws::application-load-balancer-listener listener-example
     default-action
         order: 2
         forward-action
-            target-weight
+            target-group-weight
                 target-group: $(aws::load-balancer-target-group target-group-example)
                 weight: 1
             end

--- a/src/main/java/gyro/aws/elbv2/ActionResource.java
+++ b/src/main/java/gyro/aws/elbv2/ActionResource.java
@@ -48,8 +48,13 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.RedirectActi
  * .. code-block:: gyro
  *
  *     action
- *         target-group: $(aws::load-balancer-target-group target-group-example)
- *         type: "forward"
+ *         order: 1
+ *         forward-action
+ *             target-weight
+ *                 target-group: $(aws::load-balancer-target-group target-group-example)
+ *                 weight: 1
+ *             end
+ *         end
  *     end
  */
 public class ActionResource extends AwsResource implements Copyable<Action> {
@@ -269,6 +274,9 @@ public class ActionResource extends AwsResource implements Copyable<Action> {
         return String.format("%s/%s", getOrder(), detectType());
     }
 
+    /**
+     * Actions can only have a single type configured.
+     */
     @Override
     public List<ValidationError> validate(Set<String> configuredFields) {
         List<ValidationError> errors = new ArrayList<>();

--- a/src/main/java/gyro/aws/elbv2/ActionResource.java
+++ b/src/main/java/gyro/aws/elbv2/ActionResource.java
@@ -50,7 +50,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.RedirectActi
  *     action
  *         order: 1
  *         forward-action
- *             target-weight
+ *             target-group-weight
  *                 target-group: $(aws::load-balancer-target-group target-group-example)
  *                 weight: 1
  *             end

--- a/src/main/java/gyro/aws/elbv2/ActionResource.java
+++ b/src/main/java/gyro/aws/elbv2/ActionResource.java
@@ -16,6 +16,10 @@
 
 package gyro.aws.elbv2;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
 import gyro.aws.AwsResource;
 import gyro.aws.Copyable;
 import gyro.core.GyroUI;
@@ -25,8 +29,9 @@ import gyro.core.resource.DiffableInternals;
 import gyro.core.resource.Resource;
 import gyro.core.diff.Update;
 import gyro.core.resource.Updatable;
-
 import gyro.core.scope.State;
+import gyro.core.validation.ValidationError;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.Action;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.ActionTypeEnum;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.AuthenticateCognitoActionConfig;
@@ -34,8 +39,6 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.Authenticate
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.FixedResponseActionConfig;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.ForwardActionConfig;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.RedirectActionConfig;
-
-import java.util.Set;
 
 /**
  *
@@ -264,6 +267,33 @@ public class ActionResource extends AwsResource implements Copyable<Action> {
     @Override
     public String primaryKey() {
         return String.format("%s/%s", getOrder(), detectType());
+    }
+
+    @Override
+    public List<ValidationError> validate(Set<String> configuredFields) {
+        List<ValidationError> errors = new ArrayList<>();
+        List<String> types = new ArrayList<>();
+        if (getAuthenticateCognitoAction() != null) {
+            types.add(ActionTypeEnum.AUTHENTICATE_COGNITO.toString());
+        }
+        if (getAuthenticateOidcAction() != null) {
+            types.add(ActionTypeEnum.AUTHENTICATE_OIDC.toString());
+        }
+        if (getFixedResponseAction() != null) {
+            types.add(ActionTypeEnum.FIXED_RESPONSE.toString());
+        }
+        if (getForwardAction() != null) {
+            types.add(ActionTypeEnum.FORWARD.toString());
+        }
+
+        if (types.size() > 1) {
+            errors.add(new ValidationError(
+                this,
+                "type",
+                String.format("Action Resource must have exactly 1 type. Types defined: [ %s ]", StringUtils.join(types, ","))));
+        }
+
+        return errors;
     }
 }
 

--- a/src/main/java/gyro/aws/elbv2/ActionResource.java
+++ b/src/main/java/gyro/aws/elbv2/ActionResource.java
@@ -252,6 +252,8 @@ public class ActionResource extends AwsResource implements Copyable<Action> {
             return ActionTypeEnum.FIXED_RESPONSE.toString();
         } else if (getForwardAction() != null) {
             return ActionTypeEnum.FORWARD.toString();
+        } else if (getRedirectAction() != null) {
+            return ActionTypeEnum.REDIRECT.toString();
         } else {
             return ActionTypeEnum.UNKNOWN_TO_SDK_VERSION.toString();
         }

--- a/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerResource.java
+++ b/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerResource.java
@@ -49,8 +49,12 @@ import java.util.Set;
  *         default-certificate: "arn:aws:acm:us-east-2:acct:certificate/certificate-arn"
  *
  *         default-action
- *             target-group-arn: $(aws::load-balancer-target-group target-group-example | target-group-arn)
- *             type: "forward"
+ *             forward-action
+ *                target-group-weight
+ *                    target-group: $(aws::load-balancer-target-group target-group-example)
+ *                    weight: 1
+ *                end
+ *            end
  *         end
  *     end
  */

--- a/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerRuleResource.java
+++ b/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerRuleResource.java
@@ -52,7 +52,7 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.RuleNotFound
  *
  *         action
  *             forward-action
- *                 target-weight
+ *                 target-group-weight
  *                     target-group: $(aws::load-balancer-target-group target-group-example)
  *                     weight: 1
  *                 end

--- a/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerRuleResource.java
+++ b/src/main/java/gyro/aws/elbv2/ApplicationLoadBalancerListenerRuleResource.java
@@ -51,8 +51,12 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.RuleNotFound
  *         priority: "1"
  *
  *         action
- *             target-group: $(aws::load-balancer-target-group target-group-example | target-group-arn)
- *             type: "forward"
+ *             forward-action
+ *                 target-weight
+ *                     target-group: $(aws::load-balancer-target-group target-group-example)
+ *                     weight: 1
+ *                 end
+ *             end
  *         end
  *
  *         condition

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -131,6 +131,6 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
 
     @Override
     public String primaryKey() {
-        return "forward-action";
+        return "";
     }
 }

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -9,7 +9,6 @@ import java.util.stream.Collectors;
 import gyro.aws.Copyable;
 import gyro.core.resource.Diffable;
 import gyro.core.resource.Updatable;
-import gyro.core.validation.ValidationError;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.ForwardActionConfig;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupStickinessConfig;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupTuple;
@@ -100,15 +99,6 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
 
     @Override
     public String primaryKey() {
-        return getTargetGroup().stream()
-            .map(TargetGroupTupleResource::getTargetGroupArn)
-            .filter(Objects::nonNull)
-            .collect(Collectors.joining("/"));
-    }
-
-    @Override
-    public List<ValidationError> validate(Set<String> configuredFields) {
-        List<ValidationError> errors = new ArrayList<>();
-        return errors;
+        return "forward-action";
     }
 }

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -13,11 +13,36 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.ForwardActio
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupStickinessConfig;
 import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupTuple;
 
+/**
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *     forward-action
+ *         target-weight
+ *             target-group: $(aws::load-balancer-target-group target-group-example)
+ *             weight: 1
+ *         end
+ *         target-weight
+ *             target-group: $(aws::load-balancer-target-group target-group-example-2)
+ *             weight: 1
+ *         end
+ *         target-group-stickiness
+ *             enabled: true
+ *             duration: 60
+ *         end
+ *     end
+ */
 public class ForwardAction extends Diffable implements Copyable<ForwardActionConfig> {
 
     private List<TargetGroupTupleResource> targetGroupWeight;
     private TargetGroupStickiness targetGroupStickiness;
 
+    /**
+     * A list of target groups and their associated weight for forwarding.
+     */
     @Updatable
     public List<TargetGroupTupleResource> getTargetGroupWeight() {
         return targetGroupWeight == null ?
@@ -29,6 +54,9 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
         this.targetGroupWeight = targetGroupWeight;
     }
 
+    /**
+     * The Configuration to determine if subsequent requests should stay with the same target group
+     */
     @Updatable
     public TargetGroupStickiness getTargetGroupStickiness() {
         return targetGroupStickiness;

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -21,11 +21,11 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupT
  * .. code-block:: gyro
  *
  *     forward-action
- *         target-weight
+ *         target-group-weight
  *             target-group: $(aws::load-balancer-target-group target-group-example)
  *             weight: 1
  *         end
- *         target-weight
+ *         target-group-weight
  *             target-group: $(aws::load-balancer-target-group target-group-example-2)
  *             weight: 1
  *         end

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -41,7 +41,9 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
     private TargetGroupStickiness targetGroupStickiness;
 
     /**
-     * A list of target groups and their associated weight for forwarding.
+     * The list of target groups and their associated weight for forwarding.
+     *
+     * @subresource gyro.aws.elbv2.TargetGroupTupleResource
      */
     @Updatable
     public List<TargetGroupTupleResource> getTargetGroupWeight() {
@@ -55,7 +57,9 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
     }
 
     /**
-     * The Configuration to determine if subsequent requests should stay with the same target group
+     * The configuration to determine if subsequent requests should stay with the same target group.
+     *
+     * @subresource gyro.aws.elbv2.TargetGroupStickiness
      */
     @Updatable
     public TargetGroupStickiness getTargetGroupStickiness() {

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -39,6 +39,22 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
         this.targetGroupStickiness = targetGroupStickiness;
     }
 
+    public void addTargets (String... targetGroupArns) {
+        Set<String> existingTargetGroups = getTargetGroupWeight().stream()
+            .map(TargetGroupTupleResource::getTargetGroupArn)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        for (String targetGroupArn : targetGroupArns) {
+            TargetGroupResource targetGroupResource = findById(TargetGroupResource.class, targetGroupArn);
+            if (!existingTargetGroups.contains(targetGroupArn) && targetGroupResource != null) {
+                TargetGroupTupleResource tupleResource = newSubresource(TargetGroupTupleResource.class);
+                tupleResource.setTargetGroup(targetGroupResource);
+                getTargetGroupWeight().add(tupleResource);
+            }
+        }
+    }
+
     @Override
     public void copyFrom(ForwardActionConfig forwardActionConfig) {
 

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -1,0 +1,98 @@
+package gyro.aws.elbv2;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import gyro.aws.Copyable;
+import gyro.core.resource.Diffable;
+import gyro.core.resource.Updatable;
+import gyro.core.validation.ValidationError;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.ForwardActionConfig;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupStickinessConfig;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupTuple;
+
+public class ForwardAction extends Diffable implements Copyable<ForwardActionConfig> {
+
+    private List<TargetGroupTupleResource> targetGroup;
+    private TargetGroupStickiness targetGroupStickiness;
+
+    @Updatable
+    public List<TargetGroupTupleResource> getTargetGroup() {
+        return targetGroup == null ?
+            targetGroup = new ArrayList<>() :
+            targetGroup;
+    }
+
+    public void setTargetGroup(List<TargetGroupTupleResource> targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    @Updatable
+    public TargetGroupStickiness getTargetGroupStickiness() {
+        return targetGroupStickiness;
+    }
+
+    public void setTargetGroupStickiness(TargetGroupStickiness targetGroupStickiness) {
+        this.targetGroupStickiness = targetGroupStickiness;
+    }
+
+    @Override
+    public void copyFrom(ForwardActionConfig forwardActionConfig) {
+
+        getTargetGroup().clear();
+        if (forwardActionConfig.hasTargetGroups()) {
+            for (TargetGroupTuple targetGroupTuple : forwardActionConfig.targetGroups()) {
+                TargetGroupTupleResource targetGroupWeight = newSubresource(TargetGroupTupleResource.class);
+                targetGroupWeight.copyFrom(targetGroupTuple);
+                getTargetGroup().add(targetGroupWeight);
+            }
+        }
+
+        TargetGroupStickinessConfig targetGroupStickinessConfig = forwardActionConfig.targetGroupStickinessConfig();
+        if (targetGroupStickinessConfig != null) {
+            TargetGroupStickiness targetGroupStickiness = newSubresource(TargetGroupStickiness.class);
+            targetGroupStickiness.copyFrom(targetGroupStickinessConfig);
+        }
+    }
+
+    public List<TargetGroupTuple> toTargetGroupTuples() {
+        return getTargetGroup().stream()
+            .map(TargetGroupTupleResource::toTargetGroupTuple)
+            .collect(Collectors.toList());
+    }
+
+    public TargetGroupStickinessConfig toTargetGroupStickinessConfig() {
+        if (getTargetGroupStickiness() != null) {
+            return TargetGroupStickinessConfig.builder()
+                .durationSeconds(getTargetGroupStickiness().getDuration())
+                .enabled(getTargetGroupStickiness().getEnabled())
+                .build();
+        }
+
+        return null;
+    }
+
+    public ForwardActionConfig toForwardActionConfig() {
+        return ForwardActionConfig.builder()
+            .targetGroups(toTargetGroupTuples())
+            .targetGroupStickinessConfig(toTargetGroupStickinessConfig())
+            .build();
+    }
+
+    @Override
+    public String primaryKey() {
+        return getTargetGroup().stream()
+            .map(TargetGroupTupleResource::getTargetGroupArn)
+            .filter(Objects::nonNull)
+            .collect(Collectors.joining("/"));
+    }
+
+    @Override
+    public List<ValidationError> validate(Set<String> configuredFields) {
+        List<ValidationError> errors = new ArrayList<>();
+        return errors;
+    }
+}

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -16,18 +16,18 @@ import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupT
 
 public class ForwardAction extends Diffable implements Copyable<ForwardActionConfig> {
 
-    private List<TargetGroupTupleResource> targetGroup;
+    private List<TargetGroupTupleResource> targetGroupWeight;
     private TargetGroupStickiness targetGroupStickiness;
 
     @Updatable
-    public List<TargetGroupTupleResource> getTargetGroup() {
-        return targetGroup == null ?
-            targetGroup = new ArrayList<>() :
-            targetGroup;
+    public List<TargetGroupTupleResource> getTargetGroupWeight() {
+        return targetGroupWeight == null ?
+            targetGroupWeight = new ArrayList<>() :
+            targetGroupWeight;
     }
 
-    public void setTargetGroup(List<TargetGroupTupleResource> targetGroup) {
-        this.targetGroup = targetGroup;
+    public void setTargetGroupWeight(List<TargetGroupTupleResource> targetGroupWeight) {
+        this.targetGroupWeight = targetGroupWeight;
     }
 
     @Updatable
@@ -42,12 +42,12 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
     @Override
     public void copyFrom(ForwardActionConfig forwardActionConfig) {
 
-        getTargetGroup().clear();
+        getTargetGroupWeight().clear();
         if (forwardActionConfig.hasTargetGroups()) {
             for (TargetGroupTuple targetGroupTuple : forwardActionConfig.targetGroups()) {
                 TargetGroupTupleResource targetGroupWeight = newSubresource(TargetGroupTupleResource.class);
                 targetGroupWeight.copyFrom(targetGroupTuple);
-                getTargetGroup().add(targetGroupWeight);
+                getTargetGroupWeight().add(targetGroupWeight);
             }
         }
 
@@ -59,7 +59,7 @@ public class ForwardAction extends Diffable implements Copyable<ForwardActionCon
     }
 
     public List<TargetGroupTuple> toTargetGroupTuples() {
-        return getTargetGroup().stream()
+        return getTargetGroupWeight().stream()
             .map(TargetGroupTupleResource::toTargetGroupTuple)
             .collect(Collectors.toList());
     }

--- a/src/main/java/gyro/aws/elbv2/ForwardAction.java
+++ b/src/main/java/gyro/aws/elbv2/ForwardAction.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Brightspot.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.aws.elbv2;
 
 import java.util.ArrayList;

--- a/src/main/java/gyro/aws/elbv2/TargetGroupResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupResource.java
@@ -209,31 +209,6 @@ public class TargetGroupResource extends AwsResource implements Copyable<TargetG
         this.vpc = vpc;
     }
 
-    /**
-     * Helper method that maps Health State to instances in that state.
-     *
-     * @return A map of health state to number of targets in that state
-     */
-    public Map<String, Integer> targetHealth() {
-        Map<String, Integer> healthMap = new HashMap<>();
-
-        ElasticLoadBalancingV2Client client = createClient(ElasticLoadBalancingV2Client.class);
-        List<TargetHealthDescription> targetHealthDescriptions = client.describeTargetHealth(
-            DescribeTargetHealthRequest.builder()
-                .targetGroupArn(getArn())
-                .build())
-            .targetHealthDescriptions();
-
-        for (TargetHealthDescription thd : targetHealthDescriptions) {
-            String state = thd.targetHealth().stateAsString();
-            int count = healthMap.getOrDefault(state, 0);
-            healthMap.put(state, count + 1);
-        }
-
-        healthMap.put("Total", targetHealthDescriptions.size());
-        return healthMap;
-    }
-
     @Override
     public void copyFrom(TargetGroup targetGroup) {
         if (getHealthCheck() != null) {

--- a/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
@@ -10,6 +10,9 @@ public class TargetGroupStickiness extends Diffable implements Copyable<TargetGr
     private Boolean enabled;
     private Integer duration;
 
+    /**
+     * Determines if requests should be directed to the same target group
+     */
     @Updatable
     public Boolean getEnabled() {
         return enabled;
@@ -19,6 +22,9 @@ public class TargetGroupStickiness extends Diffable implements Copyable<TargetGr
         this.enabled = enabled;
     }
 
+    /**
+     * How long requests should be directed to the same target group
+     */
     @Updatable
     public Integer getDuration() {
         return duration;

--- a/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
@@ -1,0 +1,41 @@
+package gyro.aws.elbv2;
+
+import gyro.aws.Copyable;
+import gyro.core.resource.Diffable;
+import gyro.core.resource.Updatable;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupStickinessConfig;
+
+public class TargetGroupStickiness extends Diffable implements Copyable<TargetGroupStickinessConfig> {
+
+    private Boolean enabled;
+    private Integer duration;
+
+    @Updatable
+    public Boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    @Updatable
+    public Integer getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Integer duration) {
+        this.duration = duration;
+    }
+
+    @Override
+    public void copyFrom(TargetGroupStickinessConfig targetGroupStickinessConfig) {
+        setDuration(targetGroupStickinessConfig.durationSeconds());
+        setEnabled(targetGroupStickinessConfig.enabled());
+    }
+
+    @Override
+    public String primaryKey() {
+        return String.format("%s:%s", getDuration(), getEnabled());
+    }
+}

--- a/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
@@ -11,7 +11,7 @@ public class TargetGroupStickiness extends Diffable implements Copyable<TargetGr
     private Integer duration;
 
     /**
-     * Determines if requests should be directed to the same target group
+     * When set to ``true``, the requests will be directed to the same target group
      */
     @Updatable
     public Boolean getEnabled() {
@@ -23,7 +23,7 @@ public class TargetGroupStickiness extends Diffable implements Copyable<TargetGr
     }
 
     /**
-     * How long requests should be directed to the same target group
+     * The amount of time for which requests should be directed to the same target group
      */
     @Updatable
     public Integer getDuration() {

--- a/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
@@ -42,6 +42,6 @@ public class TargetGroupStickiness extends Diffable implements Copyable<TargetGr
 
     @Override
     public String primaryKey() {
-        return String.format("%s:%s", getDuration(), getEnabled());
+        return "";
     }
 }

--- a/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupStickiness.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Brightspot.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.aws.elbv2;
 
 import gyro.aws.Copyable;

--- a/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
@@ -1,0 +1,54 @@
+package gyro.aws.elbv2;
+
+import gyro.aws.Copyable;
+import gyro.core.resource.Diffable;
+import gyro.core.resource.Updatable;
+import software.amazon.awssdk.services.elasticloadbalancingv2.model.TargetGroupTuple;
+
+public class TargetGroupTupleResource extends Diffable implements Copyable<TargetGroupTuple> {
+
+    private TargetGroupResource targetGroup;
+    private Integer weight;
+
+    @Updatable
+    public TargetGroupResource getTargetGroup() {
+        return targetGroup;
+    }
+
+    public void setTargetGroup(TargetGroupResource targetGroup) {
+        this.targetGroup = targetGroup;
+    }
+
+    @Updatable
+    public Integer getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Integer weight) {
+        this.weight = weight;
+    }
+
+    @Override
+    public String primaryKey() {
+        return String.format("%s::%s", getTargetGroup().getArn(), getWeight());
+    }
+
+    public String getTargetGroupArn() {
+        return getTargetGroup() != null ?
+            getTargetGroup().getArn() :
+            null;
+    }
+
+    @Override
+    public void copyFrom(TargetGroupTuple targetGroupTuple) {
+        setTargetGroup(targetGroupTuple.targetGroupArn() != null ? findById(TargetGroupResource.class, targetGroupTuple.targetGroupArn()) : null);
+        setWeight(targetGroupTuple.weight());
+    }
+
+    public TargetGroupTuple toTargetGroupTuple() {
+        return TargetGroupTuple.builder()
+            .targetGroupArn(getTargetGroup().getArn())
+            .weight(getWeight())
+            .build();
+    }
+}

--- a/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
@@ -10,6 +10,9 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
     private TargetGroupResource targetGroup;
     private Integer weight;
 
+    /**
+     * The Target group to which requests are forwarded
+     */
     @Updatable
     public TargetGroupResource getTargetGroup() {
         return targetGroup;
@@ -19,6 +22,10 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
         this.targetGroup = targetGroup;
     }
 
+    /**
+     * The weight of the ratio of requests forwarded to the given target group.
+     * The ratio is this weight / total weights from all Target groups configured
+     */
     @Updatable
     public Integer getWeight() {
         return weight == null ?

--- a/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
@@ -11,7 +11,7 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
     private Integer weight;
 
     /**
-     * The Target group to which requests are forwarded
+     * The target group to which requests are forwarded
      */
     @Updatable
     public TargetGroupResource getTargetGroup() {
@@ -24,7 +24,7 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
 
     /**
      * The weight of the ratio of requests forwarded to the given target group.
-     * The ratio is this weight / total weights from all Target groups configured
+     * The ratio is this weight / total weights from all target groups configured
      */
     @Updatable
     public Integer getWeight() {

--- a/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
@@ -21,7 +21,9 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
 
     @Updatable
     public Integer getWeight() {
-        return weight;
+        return weight == null ?
+            weight = 1 :
+            weight;
     }
 
     public void setWeight(Integer weight) {
@@ -30,7 +32,7 @@ public class TargetGroupTupleResource extends Diffable implements Copyable<Targe
 
     @Override
     public String primaryKey() {
-        return String.format("%s::%s", getTargetGroup().getArn(), getWeight());
+        return String.format("%s/%s", getTargetGroup().getArn(), getWeight());
     }
 
     public String getTargetGroupArn() {

--- a/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
+++ b/src/main/java/gyro/aws/elbv2/TargetGroupTupleResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Brightspot.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.aws.elbv2;
 
 import gyro.aws.Copyable;


### PR DESCRIPTION
Fixes: https://github.com/perfectsense/gyro-aws-provider/issues/448
This PR makes ALB Forwarding actions comparable to console configuration. This allows an Application Load Balancer Listener rule to forward to multiple target groups and to adjust the weight of them.