### PR TITLE
Revert "Remove unused field customize error response"

### DIFF
--- a/src/main/java/gyro/aws/cloudfront/CloudFrontCustomErrorResponse.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontCustomErrorResponse.java
@@ -26,6 +26,7 @@ public class CloudFrontCustomErrorResponse extends Diffable implements Copyable<
     private Integer errorCode;
     private String responseCode;
     private String responsePagePath;
+    private Boolean customizeErrorResponse;
 
     /**
      * The minimum amount of time to cache this error code.
@@ -77,6 +78,18 @@ public class CloudFrontCustomErrorResponse extends Diffable implements Copyable<
 
     public void setResponsePagePath(String responsePagePath) {
         this.responsePagePath = responsePagePath;
+    }
+
+    public Boolean getCustomizeErrorResponse() {
+        if (customizeErrorResponse == null) {
+            customizeErrorResponse = false;
+        }
+
+        return customizeErrorResponse;
+    }
+
+    public void setCustomizeErrorResponse(Boolean customizeErrorResponse) {
+        this.customizeErrorResponse = customizeErrorResponse;
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 73eca8d83331b5fdef655fd75069f211537b45ca.

Removal of this field causes backward compatibility issue.
We should look into deprecating fields before removal.