### PR TITLE
Make Ecr repository fields updatable

### DIFF
--- a/src/main/java/gyro/aws/ecr/EcrImageScanningConfiguration.java
+++ b/src/main/java/gyro/aws/ecr/EcrImageScanningConfiguration.java
@@ -18,6 +18,7 @@ package gyro.aws.ecr;
 
 import gyro.aws.Copyable;
 import gyro.core.resource.Diffable;
+import gyro.core.resource.Updatable;
 import gyro.core.validation.Required;
 import software.amazon.awssdk.services.ecr.model.ImageScanningConfiguration;
 
@@ -28,6 +29,7 @@ public class EcrImageScanningConfiguration extends Diffable implements Copyable<
     /**
      * When set to ``true``, images are scanned after being pushed to a repository.
      */
+    @Updatable
     @Required
     public Boolean getScanOnPush() {
         return scanOnPush;

--- a/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
+++ b/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
@@ -121,6 +121,10 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
     @Updatable
     @ValidStrings({ "MUTABLE", "IMMUTABLE" })
     public ImageTagMutability getImageTagMutability() {
+        if (imageTagMutability == null) {
+            imageTagMutability = ImageTagMutability.MUTABLE;
+        }
+
         return imageTagMutability;
     }
 
@@ -336,8 +340,7 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
 
         if (changedFieldNames.contains("image-tag-mutability")) {
             client.putImageTagMutability(r -> r.repositoryName(getRepositoryName())
-                .imageTagMutability(
-                    getImageTagMutability() == null ? ImageTagMutability.MUTABLE : getImageTagMutability()));
+                .imageTagMutability(getImageTagMutability()));
         }
 
         if (changedFieldNames.contains("image-scanning-configuration")) {

--- a/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
+++ b/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
@@ -106,6 +106,7 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
      *
      * @subresource gyro.aws.ecr.EcrImageScanningConfiguration
      */
+    @Updatable
     public EcrImageScanningConfiguration getImageScanningConfiguration() {
         return imageScanningConfiguration;
     }
@@ -117,6 +118,7 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
     /**
      * The tag mutability setting for the repository.
      */
+    @Updatable
     @ValidStrings({ "MUTABLE", "IMMUTABLE" })
     public ImageTagMutability getImageTagMutability() {
         return imageTagMutability;
@@ -330,6 +332,19 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
             } else {
                 putLifecyclePolicy(client);
             }
+        }
+
+        if (changedFieldNames.contains("image-tag-mutability")) {
+            client.putImageTagMutability(r -> r.repositoryName(getRepositoryName())
+                .imageTagMutability(
+                    getImageTagMutability() == null ? ImageTagMutability.MUTABLE : getImageTagMutability()));
+        }
+
+        if (changedFieldNames.contains("image-scanning-configuration")) {
+            client.putImageScanningConfiguration(r -> r.repositoryName(getRepositoryName())
+                .imageScanningConfiguration(getImageScanningConfiguration() != null
+                    ? getImageScanningConfiguration().toImageScanningConfiguration()
+                    : newSubresource(EcrImageScanningConfiguration.class).toImageScanningConfiguration()));
         }
     }
 

--- a/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
+++ b/src/main/java/gyro/aws/ecr/EcrRepositoryResource.java
@@ -116,7 +116,7 @@ public class EcrRepositoryResource extends AwsResource implements Copyable<Repos
     }
 
     /**
-     * The tag mutability setting for the repository.
+     * The tag mutability setting for the repository. Defaults to ``MUTABLE``.
      */
     @Updatable
     @ValidStrings({ "MUTABLE", "IMMUTABLE" })


### PR DESCRIPTION
Fixes #490 

imageScanningConfiguration imageTagMutability should be updatable.