### PR TITLE
Revert "Upgrade gyro reference to 1.1.1"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ shadowJar {
 build.dependsOn shadowJar
 
 dependencies {
-    api 'gyro:gyro-core:1.1.1' + (releaseBuild ? '' : '-SNAPSHOT')
+    api 'gyro:gyro-core:1.1.0' + (releaseBuild ? '' : '-SNAPSHOT')
 
     implementation 'com.google.guava:guava:23.0'
     implementation 'com.psddev:dari-util:3.3.607-xe0f27a'


### PR DESCRIPTION
Removes refrence gyro 1.1.1 as snapshot is not present.

This reverts commit 65c5f5f3364d8c86b8394c4025db78d791f3080f.