### PR TITLE
Bugfix: Update Security Group of ELB properly

### DIFF
--- a/src/main/java/gyro/aws/elb/LoadBalancerResource.java
+++ b/src/main/java/gyro/aws/elb/LoadBalancerResource.java
@@ -392,19 +392,10 @@ public class LoadBalancerResource extends AwsResource implements Copyable<LoadBa
 
         //-- Security Groups
 
-        List<String> pendingSecurityGroupIds = getSecurityGroups().stream()
-            .map(SecurityGroupResource::getId)
-            .collect(Collectors.toList());
-
-        List<String> currentSecurityGroupIds = currentResource.getSecurityGroups().stream()
-            .map(SecurityGroupResource::getId)
-            .collect(Collectors.toList());
-
-        List<String> sgAdditions = new ArrayList<>(pendingSecurityGroupIds);
-        sgAdditions.removeAll(currentSecurityGroupIds);
-
-        if (!sgAdditions.isEmpty()) {
-            client.applySecurityGroupsToLoadBalancer(r -> r.securityGroups(sgAdditions)
+        if (changedFieldNames.contains("security-groups")) {
+            client.applySecurityGroupsToLoadBalancer(r -> r.securityGroups(getSecurityGroups().stream()
+                .map(SecurityGroupResource::getId).collect(
+                    Collectors.toList()))
                 .loadBalancerName(getName()));
         }
 


### PR DESCRIPTION
Fixes: #523 

The security group update logic was calculating the changes made to the the existing security groups. Where as the api needed the actual list of Sg that it will update it.