### PR TITLE
Bugfix: Allow eks addons/auth to be defined outside aws::eks-cluster

### DIFF
--- a/src/main/java/gyro/aws/eks/EksAuthentication.java
+++ b/src/main/java/gyro/aws/eks/EksAuthentication.java
@@ -68,7 +68,7 @@ import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
  */
 public class EksAuthentication extends AwsResource implements Copyable<IdentityProviderConfigResponse> {
 
-    private static final String IDENTITY_PROVIDER_TYPE = "oidc";
+    protected static final String IDENTITY_PROVIDER_TYPE = "oidc";
     private String name;
     private OidcIdentityProviderConfiguration config;
     private Map<String, String> tags;

--- a/src/main/java/gyro/aws/eks/EksAuthentication.java
+++ b/src/main/java/gyro/aws/eks/EksAuthentication.java
@@ -170,7 +170,7 @@ public class EksAuthentication extends AwsResource implements Copyable<IdentityP
         client.disassociateIdentityProviderConfig(r -> r.clusterName(clusterName())
             .identityProviderConfig(i -> i.name(getName()).type(IDENTITY_PROVIDER_TYPE)));
 
-        Wait.atMost(30, TimeUnit.MINUTES)
+        Wait.atMost(60, TimeUnit.MINUTES)
             .checkEvery(2, TimeUnit.MINUTES)
             .resourceOverrides(this, TimeoutSettings.Action.DELETE)
             .prompt(false)

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonFinder.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonFinder.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2021, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.aws.eks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import gyro.aws.AwsFinder;
+import gyro.core.Type;
+import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.Addon;
+import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
+
+/**
+ * Query eks addon.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *    eks-addon: $(external-query aws::eks-addon { name: 'vpc-cni' })
+ */
+@Type("eks-addon")
+public class EksStandaloneAddonFinder extends AwsFinder<EksClient, Addon, EksStandaloneAddonResource> {
+
+    private String name;
+    private String clusterName;
+
+    /**
+     * The name of the addon.
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * The name of the cluster that the addon belongs to.
+     */
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    @Override
+    protected List<Addon> findAllAws(EksClient client) {
+        List<Addon> addons = new ArrayList<>();
+        List<String> clusters = client.listClusters().clusters();
+
+        clusters.forEach(c -> addons.addAll(client.listAddons(r -> r.clusterName(c)).addons().stream()
+            .map(a -> client.describeAddon(d -> d.clusterName(c).addonName(a)).addon())
+            .collect(Collectors.toList())));
+
+        return addons;
+    }
+
+    @Override
+    protected List<Addon> findAws(EksClient client, Map<String, String> filters) {
+        List<Addon> addons = new ArrayList<>();
+        List<String> clusters = new ArrayList<>();
+
+        if (!filters.containsKey("cluster-name")) {
+            clusters = client.listClusters().clusters();
+
+        } else {
+            clusters.add(filters.get("cluster-name"));
+        }
+
+        clusters.forEach(c -> {
+            try {
+                if (filters.containsKey("name")) {
+                    addons.add(client.describeAddon(r -> r.addonName(filters.get("name")).clusterName(c)).addon());
+
+                } else {
+                    addons.addAll(client.listAddons(r -> r.clusterName(c)).addons().stream()
+                        .map(a -> client.describeAddon(d -> d.clusterName(c).addonName(a)).addon())
+                        .collect(Collectors.toList()));
+                }
+            } catch (ResourceNotFoundException ex) {
+                // ignore
+            }
+        });
+
+        return addons;
+    }
+}

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
  *
  *     aws::eks-addon example-addon
  *         addon-name: vpc-cni
+ *         cluster: $(aws::eks-cluster ex)
  *
  *         tags : {
  *             Name: "example-addon"

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
@@ -24,6 +24,22 @@ import software.amazon.awssdk.services.eks.EksClient;
 import software.amazon.awssdk.services.eks.model.DescribeAddonResponse;
 import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
 
+/**
+ * Creates an eks addon.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *     aws::eks-addon example-addon
+ *         addon-name: vpc-cni
+ *
+ *         tags : {
+ *             Name: "example-addon"
+ *         }
+ *     end
+ */
 @Type("eks-addon")
 public class EksStandaloneAddonResource extends EksAddonResource {
 

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
@@ -21,6 +21,7 @@ import gyro.core.resource.DiffableInternals;
 import gyro.core.resource.DiffableType;
 import gyro.core.validation.Required;
 import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.Addon;
 import software.amazon.awssdk.services.eks.model.DescribeAddonResponse;
 import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
 
@@ -52,6 +53,12 @@ public class EksStandaloneAddonResource extends EksAddonResource {
 
     public void setCluster(EksClusterResource cluster) {
         this.cluster = cluster;
+    }
+
+    @Override
+    public void copyFrom(Addon model) {
+        setCluster(findById(EksClusterResource.class, model.clusterName()));
+        super.copyFrom(model);
     }
 
     @Override

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.aws.eks;
 
 import gyro.core.Type;

--- a/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAddonResource.java
@@ -1,0 +1,52 @@
+package gyro.aws.eks;
+
+import gyro.core.Type;
+import gyro.core.resource.DiffableInternals;
+import gyro.core.resource.DiffableType;
+import gyro.core.validation.Required;
+import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.DescribeAddonResponse;
+import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
+
+@Type("eks-addon")
+public class EksStandaloneAddonResource extends EksAddonResource {
+
+    private EksClusterResource cluster;
+
+    @Required
+    public EksClusterResource getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(EksClusterResource cluster) {
+        this.cluster = cluster;
+    }
+
+    @Override
+    public boolean refresh() {
+        EksClient client = createClient(EksClient.class);
+
+        try {
+            DescribeAddonResponse response = client.describeAddon(r -> r
+                .clusterName(clusterName())
+                .addonName(getAddonName()));
+
+            copyFrom(response.addon());
+        } catch (ResourceNotFoundException ex) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String primaryKey() {
+        String name = DiffableInternals.getName(this);
+        return String.format("%s::%s", DiffableType.getInstance(getClass()).getName(), name);
+    }
+
+    @Override
+    protected String clusterName() {
+        return cluster.getName();
+    }
+}

--- a/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationFinder.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationFinder.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gyro.aws.eks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import gyro.aws.AwsFinder;
+import gyro.core.GyroException;
+import gyro.core.Type;
+import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.DescribeIdentityProviderConfigResponse;
+import software.amazon.awssdk.services.eks.model.IdentityProviderConfig;
+import software.amazon.awssdk.services.eks.model.IdentityProviderConfigResponse;
+import software.amazon.awssdk.services.eks.model.ResourceNotFoundException;
+
+/**
+ * Query eks authentication.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *    eks-authentication: $(external-query aws::eks-authentication {cluster-name: "cluster-prod", name: "onelogin", type: "oidc"})
+ */
+@Type("eks-authentication")
+public class EksStandaloneAuthenticationFinder extends AwsFinder<EksClient, IdentityProviderConfigResponse, EksStandaloneAuthenticationResource> {
+
+    private String name;
+    private String type;
+    private String clusterName;
+
+    /**
+     * The name of the authentication.
+     */
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * The type of the authentication.
+     */
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    /**
+     * The name of the cluster that the authentication belongs to.
+     */
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    public void setClusterName(String clusterName) {
+        this.clusterName = clusterName;
+    }
+
+    @Override
+    protected List<IdentityProviderConfigResponse> findAllAws(EksClient client) {
+        List<IdentityProviderConfigResponse> configResponses = new ArrayList<>();
+        List<String> clusters = client.listClusters().clusters();
+
+        clusters.forEach(c -> configResponses.addAll(client.listIdentityProviderConfigs(r -> r.clusterName(c))
+            .identityProviderConfigs()
+            .stream()
+            .map(a -> client.describeIdentityProviderConfig(d -> d.clusterName(c)
+                .identityProviderConfig(i -> i.name(a.name()).type(a.type()))).identityProviderConfig())
+            .collect(Collectors.toList())));
+
+        return configResponses;
+    }
+
+    @Override
+    protected List<IdentityProviderConfigResponse> findAws(EksClient client, Map<String, String> filters) {
+        List<IdentityProviderConfigResponse> configResponses = new ArrayList<>();
+        List<String> clusters = new ArrayList<>();
+
+        if (!filters.containsKey("cluster-name")) {
+            clusters = client.listClusters().clusters();
+
+        } else {
+            clusters.add(filters.get("cluster-name"));
+        }
+
+        IdentityProviderConfig.Builder builder = IdentityProviderConfig.builder();
+
+        if (filters.containsKey("name")) {
+            builder = builder.name(filters.get("name"));
+        } else {
+            throw new GyroException("'name' is required.");
+        }
+
+        builder = builder.type(filters.getOrDefault("type", EksAuthentication.IDENTITY_PROVIDER_TYPE));
+
+        IdentityProviderConfig identityProviderConfig = builder.build();
+
+        clusters.forEach(cl -> {
+            try {
+                DescribeIdentityProviderConfigResponse response = client.describeIdentityProviderConfig(
+                    r -> r.clusterName(cl)
+                        .identityProviderConfig(identityProviderConfig));
+
+                configResponses.add(response.identityProviderConfig());
+            } catch (ResourceNotFoundException ex) {
+                // Ignore
+            }
+        });
+
+        return configResponses;
+    }
+}

--- a/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
@@ -26,6 +26,32 @@ import software.amazon.awssdk.services.eks.model.IdentityProviderConfigResponse;
 import software.amazon.awssdk.services.eks.model.ListIdentityProviderConfigsResponse;
 import software.amazon.awssdk.services.eks.model.NotFoundException;
 
+/**
+ * Creates an eks authentication.
+ *
+ * Example
+ * -------
+ *
+ * .. code-block:: gyro
+ *
+ *     aws::eks-authentication eks-authentication-example
+ *         name: "onelogin"
+ *         type: "oidc"
+ *         cluster: $(aws::eks-cluster ex)
+ *
+ *         config
+ *             client-id: "valid client id"
+ *             groups-claim: "groups"
+ *             groups-prefix: "onelogin-group:"
+ *             issuer-url: "valid issuer url"
+ *             username-prefix: "onelogin-user:"
+ *         end
+ *
+ *         tags: {
+ *             Name: "eks-authentication-example"
+ *         }
+ *     end
+ */
 @Type("eks-authentication")
 public class EksStandaloneAuthenticationResource extends EksAuthentication {
 

--- a/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
@@ -1,0 +1,65 @@
+package gyro.aws.eks;
+
+import gyro.core.Type;
+import gyro.core.resource.DiffableInternals;
+import gyro.core.resource.DiffableType;
+import gyro.core.validation.Required;
+import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.IdentityProviderConfig;
+import software.amazon.awssdk.services.eks.model.IdentityProviderConfigResponse;
+import software.amazon.awssdk.services.eks.model.ListIdentityProviderConfigsResponse;
+import software.amazon.awssdk.services.eks.model.NotFoundException;
+
+@Type("eks-authentication")
+public class EksStandaloneAuthenticationResource extends EksAuthentication {
+
+    private EksClusterResource cluster;
+
+    @Required
+    public EksClusterResource getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(EksClusterResource cluster) {
+        this.cluster = cluster;
+    }
+
+    @Override
+    public boolean refresh() {
+        EksClient client = createClient(EksClient.class);
+
+        try {
+            ListIdentityProviderConfigsResponse response = client.listIdentityProviderConfigs(r -> r
+                .clusterName(clusterName()));
+            if (response.hasIdentityProviderConfigs() && !response.identityProviderConfigs().isEmpty()) {
+                IdentityProviderConfig providerConfig = response.identityProviderConfigs().get(0);
+
+                IdentityProviderConfigResponse auth = EksAuthentication.getIdentityProviderConfigResponse(
+                    client,
+                    getName(),
+                    providerConfig.name(),
+                    providerConfig.type());
+
+                if (auth != null) {
+                    copyFrom(auth);
+                }
+            }
+        } catch (NotFoundException ex) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public String primaryKey() {
+        String name = DiffableInternals.getName(this);
+        return String.format("%s::%s", DiffableType.getInstance(getClass()).getName(), name);
+    }
+
+    @Override
+    protected String clusterName() {
+        return cluster.getName();
+    }
+
+}

--- a/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
@@ -21,6 +21,7 @@ import gyro.core.resource.DiffableInternals;
 import gyro.core.resource.DiffableType;
 import gyro.core.validation.Required;
 import software.amazon.awssdk.services.eks.EksClient;
+import software.amazon.awssdk.services.eks.model.Addon;
 import software.amazon.awssdk.services.eks.model.IdentityProviderConfig;
 import software.amazon.awssdk.services.eks.model.IdentityProviderConfigResponse;
 import software.amazon.awssdk.services.eks.model.ListIdentityProviderConfigsResponse;
@@ -64,6 +65,12 @@ public class EksStandaloneAuthenticationResource extends EksAuthentication {
 
     public void setCluster(EksClusterResource cluster) {
         this.cluster = cluster;
+    }
+
+    @Override
+    public void copyFrom(IdentityProviderConfigResponse model) {
+        setCluster(findById(EksClusterResource.class, model.oidc().clusterName()));
+        super.copyFrom(model);
     }
 
     @Override

--- a/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
+++ b/src/main/java/gyro/aws/eks/EksStandaloneAuthenticationResource.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021, Perfect Sense, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gyro.aws.eks;
 
 import gyro.core.Type;


### PR DESCRIPTION
Defining add-ons inside of the eks-cluster resource causes them to be created too soon. Specifically `coredns` will always fail when defined this way because it needs a nodegroup to be available.

Enabling authentication can take a long time. In some cases it may be possible to skip waiting for it to be finished. However, order of operations are important. If you define authentication inside the eks-cluster resource, then skip waiting for it, then create a nodegroup, the node group will most likely fail to create as it needs to wait for the eks-cluster to be ready. This happens because it can take over 30 mins for authentication setup to finish but a nodegroup will only wait 20 mins before failing.