### PR TITLE
Upgrade AWS SDK to 2.17.76

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,8 @@ dependencies {
 
     implementation 'com.google.guava:guava:23.0'
     implementation 'com.psddev:dari-util:3.3.607-xe0f27a'
-    implementation enforcedPlatform('software.amazon.awssdk:bom:2.16.96')
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.13.0'
+    implementation enforcedPlatform('software.amazon.awssdk:bom:2.17.76')
     implementation 'software.amazon.awssdk:apache-client'
     implementation 'software.amazon.awssdk:apigatewayv2'
     implementation 'software.amazon.awssdk:autoscaling'


### PR DESCRIPTION
This pulls in enum updates to allow using Bottlerocket in managed node groups.