### PR TITLE
Add support for "TLSv1.2_2021" minimum protocol version for CloudFront

### DIFF
--- a/src/main/java/gyro/aws/cloudfront/CloudFrontViewerCertificate.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontViewerCertificate.java
@@ -74,7 +74,7 @@ public class CloudFrontViewerCertificate extends Diffable implements Copyable<Vi
      * Minimum SSL protocol.
      */
     @Updatable
-    @ValidStrings({"SSLv3", "TLSv1", "TLSv1_2016", "TLSv1.1_2016", "TLSv1.2_2018", "TLSv1.2_2019"})
+    @ValidStrings({"SSLv3", "TLSv1", "TLSv1_2016", "TLSv1.1_2016", "TLSv1.2_2018", "TLSv1.2_2019", "TLSv1.2_2021"})
     public String getMinimumProtocolVersion() {
         if (minimumProtocolVersion == null) {
             minimumProtocolVersion = "TLSv1";


### PR DESCRIPTION
Fixes https://github.com/perfectsense/gyro-aws-provider/issues/551