### PR TITLE
Exclude geo restrictions from builder if they're not set

### DIFF
--- a/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
@@ -454,10 +454,6 @@ public class CloudFrontResource extends AwsResource implements Copyable<Distribu
      */
     @Updatable
     public CloudFrontGeoRestriction getGeoRestriction() {
-        if (geoRestriction == null) {
-            geoRestriction = newSubresource(CloudFrontGeoRestriction.class);
-        }
-
         return geoRestriction;
     }
 
@@ -686,7 +682,6 @@ public class CloudFrontResource extends AwsResource implements Copyable<Distribu
             .isIPV6Enabled(getIpv6Enabled())
             .webACLId(getWebAcl() != null ? getWebAcl().getWebAclId() : "")
             .aliases(a -> a.items(getCnames()).quantity(getCnames().size()))
-            .restrictions(getGeoRestriction().toRestrictions())
             .customErrorResponses(customErrorResponses)
             .defaultCacheBehavior(defaultCacheBehavior.toDefaultCacheBehavior())
             .cacheBehaviors(cacheBehaviors)
@@ -694,6 +689,10 @@ public class CloudFrontResource extends AwsResource implements Copyable<Distribu
             .logging(getLogging() != null ? getLogging().toLoggingConfig() : CloudFrontLogging.defaultLoggingConfig())
             .viewerCertificate(viewerCertificate.toViewerCertificate())
             .callerReference(getCallerReference() != null ? getCallerReference() : Long.toString(new Date().getTime()));
+
+        if (getGeoRestriction() != null) {
+            builder.restrictions(getGeoRestriction().toRestrictions());
+        }
 
         return builder.build();
     }

--- a/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
+++ b/src/main/java/gyro/aws/cloudfront/CloudFrontResource.java
@@ -692,6 +692,8 @@ public class CloudFrontResource extends AwsResource implements Copyable<Distribu
 
         if (getGeoRestriction() != null) {
             builder.restrictions(getGeoRestriction().toRestrictions());
+        } else {
+            builder.restrictions(new CloudFrontGeoRestriction().toRestrictions());
         }
 
         return builder.build();


### PR DESCRIPTION
This prevents georestrictions from being output if in state when they are not set.