### PR TITLE
Fix S3 trying to recreate encryption configuration

### DIFF
--- a/src/main/java/gyro/aws/s3/BucketResource.java
+++ b/src/main/java/gyro/aws/s3/BucketResource.java
@@ -1156,7 +1156,7 @@ public class BucketResource extends AwsResource implements Copyable<Bucket> {
                 throw ex;
 
             } else {
-                setEncryptionConfiguration(null);
+                setPublicAccessBlockConfiguration(null);
             }
         }
     }


### PR DESCRIPTION
There is currently a bug where if there is no configured `public-access-block-configuration`, gyro attempts to recreate an existing `encryption-configuration`.