### PR TITLE
Fixed validation of read and write capacities

### DIFF
--- a/src/main/java/gyro/aws/dynamodb/DynamoDbGlobalSecondaryIndex.java
+++ b/src/main/java/gyro/aws/dynamodb/DynamoDbGlobalSecondaryIndex.java
@@ -227,15 +227,14 @@ public class DynamoDbGlobalSecondaryIndex extends Diffable implements Copyable<G
         }
 
         if ("PROVISIONED".equals(parentTable.getBillingMode()) && (getReadCapacity() == null
-            || getWriteCapacity() == null)) {
+            || getWriteCapacity() == null || getReadCapacity() <= 0L || getWriteCapacity() <= 0L)) {
             errors.add(new ValidationError(
                 this,
                 null,
                 "'read-capacity' and 'write-capacity' must both be provided when the table 'billing-mode' is set to 'PROVISIONED'!"));
         }
 
-        if ("PAY_PER_REQUEST".equals(parentTable.getBillingMode()) && (getReadCapacity() != null
-            || getWriteCapacity() != null)) {
+        if ("PAY_PER_REQUEST".equals(parentTable.getBillingMode()) && ((getReadCapacity() != null && getReadCapacity() > 0) || (getWriteCapacity() != null && getWriteCapacity() > 0))) {
             errors.add(new ValidationError(
                 this,
                 null,

--- a/src/main/java/gyro/aws/dynamodb/DynamoDbGlobalSecondaryIndex.java
+++ b/src/main/java/gyro/aws/dynamodb/DynamoDbGlobalSecondaryIndex.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import gyro.aws.Copyable;
 import gyro.core.resource.Diffable;
 import gyro.core.resource.Updatable;
+import gyro.core.validation.Min;
 import gyro.core.validation.Required;
 import gyro.core.validation.ValidStrings;
 import gyro.core.validation.ValidationError;
@@ -84,6 +85,7 @@ public class DynamoDbGlobalSecondaryIndex extends Diffable implements Copyable<G
      * The maximum number of writes per second for this table before an exception is thrown. Required if ``billing-mode`` is set to ``PROVISIONED``.
      */
     @Updatable
+    @Min(1)
     public Long getWriteCapacity() {
         return writeCapacity;
     }
@@ -96,6 +98,7 @@ public class DynamoDbGlobalSecondaryIndex extends Diffable implements Copyable<G
      * The maximum number of reads per second for this table before an exception is thrown. Required if ``billing-mode`` is set to ``PROVISIONED``.
      */
     @Updatable
+    @Min(1)
     public Long getReadCapacity() {
         return readCapacity;
     }
@@ -227,7 +230,7 @@ public class DynamoDbGlobalSecondaryIndex extends Diffable implements Copyable<G
         }
 
         if ("PROVISIONED".equals(parentTable.getBillingMode()) && (getReadCapacity() == null
-            || getWriteCapacity() == null || getReadCapacity() <= 0L || getWriteCapacity() <= 0L)) {
+            || getWriteCapacity() == null)) {
             errors.add(new ValidationError(
                 this,
                 null,

--- a/src/main/java/gyro/aws/dynamodb/DynamoDbTableResource.java
+++ b/src/main/java/gyro/aws/dynamodb/DynamoDbTableResource.java
@@ -591,14 +591,14 @@ public class DynamoDbTableResource extends AwsResource implements Copyable<Table
     public List<ValidationError> validate(Set<String> configuredFields) {
         List<ValidationError> errors = new ArrayList<>();
 
-        if ("PROVISIONED".equals(getBillingMode()) && (getReadCapacity() == null || getWriteCapacity() == null)) {
+        if ("PROVISIONED".equals(getBillingMode()) && (getReadCapacity() == null || getWriteCapacity() == null || getReadCapacity() <= 0L || getWriteCapacity() <= 0L)) {
             errors.add(new ValidationError(
                 this,
                 null,
                 "'read-capacity' and 'write-capacity' must both be provided when 'billing-mode' is set to 'PROVISIONED'!"));
         }
 
-        if ("PAY_PER_REQUEST".equals(getBillingMode()) && (getReadCapacity() != null || getWriteCapacity() != null)) {
+        if ("PAY_PER_REQUEST".equals(getBillingMode()) && ((getReadCapacity() != null && getReadCapacity() > 0) || (getWriteCapacity() != null && getWriteCapacity() > 0))) {
             errors.add(new ValidationError(
                 this,
                 null,

--- a/src/main/java/gyro/aws/dynamodb/DynamoDbTableResource.java
+++ b/src/main/java/gyro/aws/dynamodb/DynamoDbTableResource.java
@@ -42,6 +42,7 @@ import gyro.core.resource.Output;
 import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
+import gyro.core.validation.Min;
 import gyro.core.validation.Regex;
 import gyro.core.validation.Required;
 import gyro.core.validation.ValidStrings;
@@ -253,6 +254,7 @@ public class DynamoDbTableResource extends AwsResource implements Copyable<Table
      * The maximum number of writes per second for this table before an exception is thrown. Required if ``billing-mode`` is set to ``PROVISIONED``.
      */
     @Updatable
+    @Min(1)
     public Long getWriteCapacity() {
         return writeCapacity;
     }
@@ -265,6 +267,7 @@ public class DynamoDbTableResource extends AwsResource implements Copyable<Table
      * The maximum number of reads per second for this table before an exception is thrown. Required if ``billing-mode`` is set to ``PROVISIONED``.
      */
     @Updatable
+    @Min(1)
     public Long getReadCapacity() {
         return readCapacity;
     }
@@ -591,7 +594,7 @@ public class DynamoDbTableResource extends AwsResource implements Copyable<Table
     public List<ValidationError> validate(Set<String> configuredFields) {
         List<ValidationError> errors = new ArrayList<>();
 
-        if ("PROVISIONED".equals(getBillingMode()) && (getReadCapacity() == null || getWriteCapacity() == null || getReadCapacity() <= 0L || getWriteCapacity() <= 0L)) {
+        if ("PROVISIONED".equals(getBillingMode()) && (getReadCapacity() == null || getWriteCapacity() == null)) {
             errors.add(new ValidationError(
                 this,
                 null,


### PR DESCRIPTION
resolves #642 

Currently, the validation only checks for `null` values in the `readCapacity` and `writeCapacity` fields (both for `PROVISIONED` and `PAY_PER_REQUEST` billing modes).

_However_, a `DescribeTableRequest` will return a `0` (zero) value for both `readCapacity` and `writeCapacity`, which will fail the validation of a `PAY_PER_REQUEST` table.

Furthermore, a `0` (zero) value for `readCapacity` and `writeCapacity` will _pass_ validation, whereas those values are below the minimum required values for a `PROVISIONED` table (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#default-limits-throughput-capacity-modes).

This PR updates the checks to validate a non-zero, positive value for `PROVISIONED` tables and a null or smaller or equal to zero value for `PAY_PER_REQUEST` tables.