### PR TITLE
Fix issue with EKS Taint updates

### DIFF
--- a/src/main/java/gyro/aws/eks/EksNodegroupResource.java
+++ b/src/main/java/gyro/aws/eks/EksNodegroupResource.java
@@ -534,14 +534,15 @@ public class EksNodegroupResource extends AwsResource implements Copyable<Nodegr
             Set<Taint> taintsToRemove = new HashSet<>(currentTaints);
             taintsToRemove.removeAll(taints);
 
-            // Taint key cannot be in both added and removed, this means it's an update, so remove from remove set.
-            Set<String> taintKeysToAddOrUpdate = taintsToAddOrUpdate.stream()
-                    .map(Taint::key)
-                    .collect(Collectors.toSet());
+            // Detect true updates.
+            // taint key and effect is the same, but the value is different.
             Set<Taint> taintsToUpdate = new HashSet<>();
-            for (Taint taint : taintsToRemove) {
-                if (taintKeysToAddOrUpdate.contains(taint.key())) {
-                    taintsToUpdate.add(taint);
+            for (Taint taintToBeRemoved : taintsToRemove) {
+                for (Taint taintToBeAdded : taintsToAddOrUpdate) {
+                    if (taintToBeRemoved.key().equals(taintToBeAdded.key()) &&
+                            taintToBeRemoved.effect().equals(taintToBeAdded.effect())) {
+                        taintsToUpdate.add(taintToBeRemoved);
+                    }
                 }
             }
             taintsToRemove.removeAll(taintsToUpdate);


### PR DESCRIPTION
EKS Taints should be unique for every key / effect combination.

The previous code would only take the key into consideration.

This PR adds a validation to detect violations of the key / effect unique constraint.
It also updates the logic to differentiate between an Add and Update.