### PR TITLE
Sort availability zones for db cluster

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -17,12 +17,12 @@
 package gyro.aws.rds;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import java.util.Collections;
 
 import com.psddev.dari.util.ObjectUtils;
 import gyro.aws.Copyable;
@@ -177,15 +177,14 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     public List<String> getAvailabilityZones() {
         if (availabilityZones == null) {
             availabilityZones = new ArrayList<>();
+        } else {
+            Collections.sort(availabilityZones);
         }
-
         return availabilityZones;
     }
 
     public void setAvailabilityZones(List<String> availabilityZones) {
-        List<String> modifiableList = new ArrayList<>(availabilityZones); // creates a new modifiable list
-        Collections.sort(modifiableList);
-        this.availabilityZones = modifiableList;
+        this.availabilityZones = availabilityZones;
     }
 
     /**
@@ -713,7 +712,8 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
 
     @Override
     public void copyFrom(DBCluster cluster) {
-        setAvailabilityZones(cluster.availabilityZones());
+        setAvailabilityZones(new ArrayList<>(cluster.availabilityZones()));
+
         setBackTrackWindow(cluster.backtrackWindow());
         setBackupRetentionPeriod(cluster.backupRetentionPeriod());
         setCharacterSetName(cluster.characterSetName());

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -178,6 +178,7 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
         if (availabilityZones == null) {
             availabilityZones = new ArrayList<>();
         }
+
         return availabilityZones;
     }
 

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -177,11 +177,11 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
         if (availabilityZones == null) {
             availabilityZones = new ArrayList<>();
         }
-
         return availabilityZones;
     }
 
     public void setAvailabilityZones(List<String> availabilityZones) {
+        Collections.sort(availabilityZones);
         this.availabilityZones = availabilityZones;
     }
 

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -22,6 +22,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+import java.util.Collections;
 
 import com.psddev.dari.util.ObjectUtils;
 import gyro.aws.Copyable;

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -182,8 +182,9 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     }
 
     public void setAvailabilityZones(List<String> availabilityZones) {
-        Collections.sort(availabilityZones);
-        this.availabilityZones = availabilityZones;
+        List<String> modifiableList = new ArrayList<>(availabilityZones); // creates a new modifiable list
+        Collections.sort(modifiableList);
+        this.availabilityZones = modifiableList;
     }
 
     /**


### PR DESCRIPTION
Fixes: https://github.com/perfectsense/gyro-aws-provider/issues/669

## Description
This pull request addresses the need to maintain a consistently sorted order of 'availability zones' in our code.

## Changes
The setter method now takes the input list of availability zones, creates a new modifiable list from it, sorts this list, and assigns it back to the availabilityZones field.