### PR TITLE
Make Master user name required for DB cluster

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -392,15 +392,12 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     /**
      * The name of the master user for the DB cluster.
      */
+    @Required
     public String getMasterUsername() {
         return masterUsername;
     }
 
     public void setMasterUsername(String masterUsername) {
-        if (masterUsername == null || masterUsername.isEmpty()) {
-            throw new GyroException("Master username cannot be null or empty");
-        }
-
         this.masterUsername = masterUsername;
     }
 

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -397,6 +397,10 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     }
 
     public void setMasterUsername(String masterUsername) {
+        if (masterUsername == null || masterUsername.isEmpty()) {
+            throw new GyroException("Master username cannot be null or empty");
+        }
+
         this.masterUsername = masterUsername;
     }
 


### PR DESCRIPTION
Fixes: https://github.com/perfectsense/gyro-aws-provider/issues/670

## Description
This PR updates the method handling the Master user name in the DB cluster class. Specifically, an exception is now thrown if an attempt is made to set a null or empty Master user name.
