### PR TITLE
Fix condition for multi-region when primary key is provided

### DIFF
--- a/src/main/java/gyro/aws/kms/KmsKeyResource.java
+++ b/src/main/java/gyro/aws/kms/KmsKeyResource.java
@@ -270,13 +270,6 @@ public class KmsKeyResource extends AwsResource implements Copyable<KeyMetadata>
      */
     @ConflictsWith("primary-kms-key")
     public Boolean getMultiRegion() {
-        if (multiRegion == null) {
-            if (getPrimaryKmsKey() != null && getPrimaryKmsKey().getMultiRegion()) {
-                multiRegion = true;
-            } else {
-                multiRegion = false;
-            }
-        }
         return multiRegion;
     }
 


### PR DESCRIPTION
### Fix issue with KMS key replication when using multi-region primary keys

---
Removed the logic to handle cases where `multi-region` value is `null`. This ensures correct behavior.


Fixes edge-case from issue #603 