### PR TITLE
Make engine version updatable for rds clusters

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -409,7 +409,6 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     /**
      * The name of the master user for the DB cluster.
      */
-    @Required
     public String getMasterUsername() {
         return masterUsername;
     }
@@ -820,12 +819,14 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
         setEnableIamDatabaseAuthentication(cluster.iamDatabaseAuthenticationEnabled());
         setEngine(cluster.engine());
 
-        String version = cluster.engineVersion();
-        if (getEngineVersion() != null) {
-            version = version.substring(0, getEngineVersion().length());
+        if (!Boolean.TRUE.equals(cluster.autoMinorVersionUpgrade())) {
+            String version = cluster.engineVersion();
+            if (getEngineVersion() != null) {
+                version = version.substring(0, getEngineVersion().length());
+            }
+            setEngineVersion(version);
         }
 
-        setEngineVersion(version);
         setEngineMode(cluster.engineMode());
         setKmsKey(cluster.kmsKeyId() != null ? findById(KmsKeyResource.class, cluster.kmsKeyId()) : null);
         setMasterUsername(cluster.masterUsername());

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -49,12 +49,15 @@ import software.amazon.awssdk.services.rds.model.CreateDbClusterResponse;
 import software.amazon.awssdk.services.rds.model.DBCluster;
 import software.amazon.awssdk.services.rds.model.DbClusterNotFoundException;
 import software.amazon.awssdk.services.rds.model.DescribeDbClustersResponse;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.InvalidDbClusterStateException;
 import software.amazon.awssdk.services.rds.model.LocalWriteForwardingStatus;
 import software.amazon.awssdk.services.rds.model.ModifyDbClusterRequest;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromS3Response;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterFromSnapshotResponse;
 import software.amazon.awssdk.services.rds.model.RestoreDbClusterToPointInTimeResponse;
+import software.amazon.awssdk.services.rds.model.UpgradeTarget;
 
 /**
  * Create a Aurora cluster.
@@ -1323,6 +1326,46 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
                     "restore-to-time",
                     "'restore-to-time' cannot be set when 'restore-type' is set to 'copy-on-write'. Use 'use-latest-restorable-time' instead and set it to `true` instead."
                 ));
+            }
+        }
+
+        // to make sure that the engine-version is not being downgraded
+        if (configuredFields.contains("engine-version") && getIdentifier() != null) {
+            RdsClient client = createClient(RdsClient.class);
+
+            try {
+                DescribeDbClustersResponse response = client.describeDBClusters(
+                    r -> r.dbClusterIdentifier(getIdentifier())
+                );
+
+                if (response.hasDbClusters() && !response.dbClusters().isEmpty()) {
+                    DBCluster dbCluster = response.dbClusters().get(0);
+                    String currentVersion = dbCluster.engineVersion();
+
+
+                    DescribeDbEngineVersionsResponse versionType = client.describeDBEngineVersions(
+                        DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
+
+                    if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
+                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
+                            .stream()
+                            .map(UpgradeTarget::engineVersion)
+                            .noneMatch(version -> version.equals(getEngineVersion()))) {
+                            errors.add(new ValidationError(
+                                this,
+                                "engine-version",
+                                String.format(
+                                    "'%s' is not a valid upgrade target for the current engine version '%s'.",
+                                    getEngineVersion(),
+                                    currentVersion
+                                )
+                            ));
+                        }
+                    }
+                }
+
+            } catch (DbClusterNotFoundException ex) {
+                // ignore if db cluster doesn't exist
             }
         }
 

--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -351,6 +351,7 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
     /**
      * The version number of the database engine to use.
      */
+    @Updatable
     public String getEngineVersion() {
         return engineVersion;
     }

--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -16,6 +16,8 @@
 
 package gyro.aws.rds;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -32,10 +34,14 @@ import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
+import gyro.core.validation.ValidationError;
 import software.amazon.awssdk.services.rds.RdsClient;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersResponse;
 import software.amazon.awssdk.services.rds.model.GlobalCluster;
 import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
+import software.amazon.awssdk.services.rds.model.UpgradeTarget;
 
 /**
  * Create a global cluster.
@@ -222,6 +228,53 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
             .resourceOverrides(this, TimeoutSettings.Action.DELETE)
             .prompt(true)
             .until(() -> isDeleted(client));
+    }
+
+    @Override
+    public List<ValidationError> validate(Set<String> configuredFields) {
+        ArrayList<ValidationError> errors = new ArrayList<>();
+
+        // to make sure that the engine-version is not being downgraded
+        if (configuredFields.contains("engine-version") && getIdentifier() != null) {
+            RdsClient client = createClient(RdsClient.class);
+
+            try {
+                DescribeGlobalClustersResponse response = client.describeGlobalClusters(
+                    r -> r.globalClusterIdentifier(getIdentifier())
+                );
+
+                if (response.hasGlobalClusters() && !response.globalClusters().isEmpty()) {
+                    GlobalCluster dbGlobalCluster = response.globalClusters().get(0);
+                    String currentVersion = dbGlobalCluster.engineVersion();
+
+
+                    DescribeDbEngineVersionsResponse versionType = client.describeDBEngineVersions(
+                        DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
+
+                    if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
+                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
+                            .stream()
+                            .map(UpgradeTarget::engineVersion)
+                            .noneMatch(version -> version.equals(getEngineVersion()))) {
+                            errors.add(new ValidationError(
+                                this,
+                                "engine-version",
+                                String.format(
+                                    "'%s' is not a valid upgrade target for the current engine version '%s'.",
+                                    getEngineVersion(),
+                                    currentVersion
+                                )
+                            ));
+                        }
+                    }
+                }
+
+            } catch (GlobalClusterNotFoundException ex) {
+                // ignore if global cluster doesn't exist
+            }
+        }
+
+        return errors;
     }
 
     private boolean isDeleted(RdsClient client) {

--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -16,23 +16,23 @@
 
 package gyro.aws.rds;
 
+import java.util.Set;
+
+import com.psddev.dari.util.ObjectUtils;
 import gyro.aws.AwsResource;
 import gyro.aws.Copyable;
 import gyro.core.GyroException;
 import gyro.core.GyroUI;
-import gyro.core.resource.Id;
-import gyro.core.resource.Updatable;
 import gyro.core.Type;
+import gyro.core.resource.Id;
 import gyro.core.resource.Resource;
-import com.psddev.dari.util.ObjectUtils;
+import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersResponse;
 import software.amazon.awssdk.services.rds.model.GlobalCluster;
 import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
-
-import java.util.Set;
 
 /**
  * Create a global cluster.
@@ -180,12 +180,12 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
         RdsClient client = createClient(RdsClient.class);
         client.createGlobalCluster(
             r -> r.databaseName(getDatabaseName())
-                    .deletionProtection(getDeletionProtection())
-                    .engine(getEngine())
-                    .engineVersion(getEngineVersion())
-                    .globalClusterIdentifier(getIdentifier())
-                    .sourceDBClusterIdentifier(getSourceDbCluster() != null ? getSourceDbCluster().getArn() : null)
-                    .storageEncrypted(getStorageEncrypted())
+                .deletionProtection(getDeletionProtection())
+                .engine(getEngine())
+                .engineVersion(getEngineVersion())
+                .globalClusterIdentifier(getIdentifier())
+                .sourceDBClusterIdentifier(getSourceDbCluster() != null ? getSourceDbCluster().getArn() : null)
+                .storageEncrypted(getStorageEncrypted())
         );
     }
 
@@ -196,8 +196,9 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
         // The modify global cluster api currently return a 500
         client.modifyGlobalCluster(
             r -> r.deletionProtection(getDeletionProtection())
-                    .globalClusterIdentifier(current.getIdentifier())
-                    .newGlobalClusterIdentifier(getIdentifier())
+                .engineVersion(getEngineVersion())
+                .globalClusterIdentifier(current.getIdentifier())
+                .newGlobalClusterIdentifier(getIdentifier())
         );
     }
 

--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -95,6 +95,7 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
     /**
      * The engine version of the Aurora global database.
      */
+    @Updatable
     public String getEngineVersion() {
         return engineVersion;
     }

--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -17,13 +17,16 @@
 package gyro.aws.rds;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import com.psddev.dari.util.ObjectUtils;
 import gyro.aws.AwsResource;
 import gyro.aws.Copyable;
 import gyro.core.GyroException;
 import gyro.core.GyroUI;
+import gyro.core.TimeoutSettings;
 import gyro.core.Type;
+import gyro.core.Wait;
 import gyro.core.resource.Id;
 import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
@@ -188,6 +191,8 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
                 .sourceDBClusterIdentifier(getSourceDbCluster() != null ? getSourceDbCluster().getArn() : null)
                 .storageEncrypted(getStorageEncrypted())
         );
+
+        waitForActiveStatus(client, TimeoutSettings.Action.CREATE);
     }
 
     @Override
@@ -201,6 +206,8 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
                 .globalClusterIdentifier(current.getIdentifier())
                 .newGlobalClusterIdentifier(getIdentifier())
         );
+
+        waitForActiveStatus(client, TimeoutSettings.Action.UPDATE);
     }
 
     @Override
@@ -209,5 +216,41 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
         client.deleteGlobalCluster(
             r -> r.globalClusterIdentifier(getIdentifier())
         );
+
+        Wait.atMost(5, TimeUnit.MINUTES)
+            .checkEvery(15, TimeUnit.SECONDS)
+            .resourceOverrides(this, TimeoutSettings.Action.DELETE)
+            .prompt(true)
+            .until(() -> isDeleted(client));
+    }
+
+    private boolean isDeleted(RdsClient client) {
+        try {
+            client.describeGlobalClusters(r -> r.globalClusterIdentifier(getIdentifier()));
+
+        } catch (GlobalClusterNotFoundException ex) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private void waitForActiveStatus(RdsClient client, TimeoutSettings.Action action) {
+        boolean waitResult = Wait.atMost(10, TimeUnit.MINUTES)
+            .checkEvery(30, TimeUnit.SECONDS)
+            .resourceOverrides(this, action)
+            .prompt(false)
+            .until(() -> isAvailable(client));
+
+        if (!waitResult) {
+            throw new GyroException("Unable to reach 'available' state for rds global db cluster - " + getIdentifier());
+        }
+    }
+
+    private boolean isAvailable(RdsClient client) {
+        DescribeGlobalClustersResponse response =
+            client.describeGlobalClusters(r -> r.globalClusterIdentifier(getIdentifier()));
+
+        return response.globalClusters().get(0).status().equals("available");
     }
 }

--- a/src/main/java/gyro/aws/rds/DbInstanceResource.java
+++ b/src/main/java/gyro/aws/rds/DbInstanceResource.java
@@ -16,6 +16,7 @@
 
 package gyro.aws.rds;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -40,14 +41,18 @@ import gyro.core.validation.Range;
 import gyro.core.validation.Required;
 import gyro.core.validation.ValidNumbers;
 import gyro.core.validation.ValidStrings;
+import gyro.core.validation.ValidationError;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership;
 import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
+import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.InvalidDbInstanceStateException;
+import software.amazon.awssdk.services.rds.model.UpgradeTarget;
 
 /**
  * Create a db instance.
@@ -1086,6 +1091,53 @@ public class DbInstanceResource extends RdsTaggableResource implements Copyable<
             .resourceOverrides(this, TimeoutSettings.Action.DELETE)
             .prompt(true)
             .until(() -> isDeleted(client));
+    }
+
+    @Override
+    public List<ValidationError> validate(Set<String> configuredFields) {
+        ArrayList<ValidationError> errors = new ArrayList<>();
+
+        // to make sure that the engine-version is not being downgraded
+        if (configuredFields.contains("engine-version") && getIdentifier() != null) {
+            RdsClient client = createClient(RdsClient.class);
+
+            try {
+                DescribeDbInstancesResponse response = client.describeDBInstances(
+                    r -> r.dbInstanceIdentifier(getIdentifier())
+                );
+
+                if (response.hasDbInstances() && !response.dbInstances().isEmpty()) {
+                    DBInstance dbInstance = response.dbInstances().get(0);
+                    String currentVersion = dbInstance.engineVersion();
+
+
+                    DescribeDbEngineVersionsResponse versionType = client.describeDBEngineVersions(
+                        DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
+
+                    if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
+                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
+                            .stream()
+                            .map(UpgradeTarget::engineVersion)
+                            .noneMatch(version -> version.equals(getEngineVersion()))) {
+                            errors.add(new ValidationError(
+                                this,
+                                "engine-version",
+                                String.format(
+                                    "'%s' is not a valid upgrade target for the current engine version '%s'.",
+                                    getEngineVersion(),
+                                    currentVersion
+                                )
+                            ));
+                        }
+                    }
+                }
+
+            } catch (DbInstanceNotFoundException ex) {
+                // ignore if db instance doesn't exist
+            }
+        }
+
+        return errors;
     }
 
     private boolean isDeleted(RdsClient client) {

--- a/src/main/java/gyro/aws/rds/DbInstanceResource.java
+++ b/src/main/java/gyro/aws/rds/DbInstanceResource.java
@@ -809,12 +809,15 @@ public class DbInstanceResource extends RdsTaggableResource implements Copyable<
         setEnablePerformanceInsights(instance.performanceInsightsEnabled());
         setEngine(instance.engine());
 
-        String version = instance.engineVersion();
-        if (getEngineVersion() != null) {
-            version = version.substring(0, getEngineVersion().length());
+
+        if (!Boolean.TRUE.equals(instance.autoMinorVersionUpgrade())) {
+            String version = instance.engineVersion();
+            if (getEngineVersion() != null) {
+                version = version.substring(0, getEngineVersion().length());
+            }
+            setEngineVersion(version);
         }
 
-        setEngineVersion(version);
         setIops(instance.iops());
         setKmsKey(instance.kmsKeyId() != null ? findById(KmsKeyResource.class, instance.kmsKeyId()) : null);
         setLicenseModel(instance.licenseModel());


### PR DESCRIPTION
Updates both the `db-cluster` and the `db-global-cluster`
Fixes #729 