### PR TITLE
Allow same engine version in RDS cluster validation

### DIFF
--- a/src/main/java/gyro/aws/rds/DbClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbClusterResource.java
@@ -1347,10 +1347,12 @@ public class DbClusterResource extends RdsTaggableResource implements Copyable<D
                         DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
 
                     if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
-                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
-                            .stream()
-                            .map(UpgradeTarget::engineVersion)
-                            .noneMatch(version -> version.equals(getEngineVersion()))) {
+                        // Allow same version (no change needed)
+                        if (!currentVersion.equals(getEngineVersion()) &&
+                            versionType.dbEngineVersions().get(0).validUpgradeTarget()
+                                .stream()
+                                .map(UpgradeTarget::engineVersion)
+                                .noneMatch(version -> version.equals(getEngineVersion()))) {
                             errors.add(new ValidationError(
                                 this,
                                 "engine-version",

--- a/src/main/java/gyro/aws/rds/DbInstanceResource.java
+++ b/src/main/java/gyro/aws/rds/DbInstanceResource.java
@@ -1115,7 +1115,8 @@ public class DbInstanceResource extends RdsTaggableResource implements Copyable<
                         DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
 
                     if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
-                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
+                        if (!currentVersion.equals(getEngineVersion()) &&
+                            versionType.dbEngineVersions().get(0).validUpgradeTarget()
                             .stream()
                             .map(UpgradeTarget::engineVersion)
                             .noneMatch(version -> version.equals(getEngineVersion()))) {


### PR DESCRIPTION
This pull request makes a targeted change to the `validate` method in `DbClusterResource.java` to improve handling of engine version upgrades. The main improvement is to allow the current engine version to remain unchanged without triggering a validation error.

Validation logic improvement:

* Updated the engine version validation in the `validate` method to allow the same version as the current one, preventing unnecessary validation errors when no upgrade is intended.