### PR TITLE
Remove incorrect aurora validation

### DIFF
--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -16,8 +16,6 @@
 
 package gyro.aws.rds;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -34,14 +32,10 @@ import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
 import gyro.core.validation.Required;
-import gyro.core.validation.ValidationError;
 import software.amazon.awssdk.services.rds.RdsClient;
-import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeGlobalClustersResponse;
 import software.amazon.awssdk.services.rds.model.GlobalCluster;
 import software.amazon.awssdk.services.rds.model.GlobalClusterNotFoundException;
-import software.amazon.awssdk.services.rds.model.UpgradeTarget;
 
 /**
  * Create a global cluster.
@@ -228,53 +222,6 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
             .resourceOverrides(this, TimeoutSettings.Action.DELETE)
             .prompt(true)
             .until(() -> isDeleted(client));
-    }
-
-    @Override
-    public List<ValidationError> validate(Set<String> configuredFields) {
-        ArrayList<ValidationError> errors = new ArrayList<>();
-
-        // to make sure that the engine-version is not being downgraded
-        if (configuredFields.contains("engine-version") && getIdentifier() != null) {
-            RdsClient client = createClient(RdsClient.class);
-
-            try {
-                DescribeGlobalClustersResponse response = client.describeGlobalClusters(
-                    r -> r.globalClusterIdentifier(getIdentifier())
-                );
-
-                if (response.hasGlobalClusters() && !response.globalClusters().isEmpty()) {
-                    GlobalCluster dbGlobalCluster = response.globalClusters().get(0);
-                    String currentVersion = dbGlobalCluster.engineVersion();
-
-
-                    DescribeDbEngineVersionsResponse versionType = client.describeDBEngineVersions(
-                        DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
-
-                    if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
-                        if (versionType.dbEngineVersions().get(0).validUpgradeTarget()
-                            .stream()
-                            .map(UpgradeTarget::engineVersion)
-                            .noneMatch(version -> version.equals(getEngineVersion()))) {
-                            errors.add(new ValidationError(
-                                this,
-                                "engine-version",
-                                String.format(
-                                    "'%s' is not a valid upgrade target for the current engine version '%s'.",
-                                    getEngineVersion(),
-                                    currentVersion
-                                )
-                            ));
-                        }
-                    }
-                }
-
-            } catch (GlobalClusterNotFoundException ex) {
-                // ignore if global cluster doesn't exist
-            }
-        }
-
-        return errors;
     }
 
     private boolean isDeleted(RdsClient client) {

--- a/src/main/java/gyro/aws/rds/DbInstanceResource.java
+++ b/src/main/java/gyro/aws/rds/DbInstanceResource.java
@@ -16,7 +16,6 @@
 
 package gyro.aws.rds;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -41,18 +40,14 @@ import gyro.core.validation.Range;
 import gyro.core.validation.Required;
 import gyro.core.validation.ValidNumbers;
 import gyro.core.validation.ValidStrings;
-import gyro.core.validation.ValidationError;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.model.CreateDbInstanceResponse;
 import software.amazon.awssdk.services.rds.model.DBInstance;
 import software.amazon.awssdk.services.rds.model.DBSecurityGroupMembership;
 import software.amazon.awssdk.services.rds.model.DbInstanceNotFoundException;
-import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsRequest;
-import software.amazon.awssdk.services.rds.model.DescribeDbEngineVersionsResponse;
 import software.amazon.awssdk.services.rds.model.DescribeDbInstancesResponse;
 import software.amazon.awssdk.services.rds.model.DomainMembership;
 import software.amazon.awssdk.services.rds.model.InvalidDbInstanceStateException;
-import software.amazon.awssdk.services.rds.model.UpgradeTarget;
 
 /**
  * Create a db instance.
@@ -1091,54 +1086,6 @@ public class DbInstanceResource extends RdsTaggableResource implements Copyable<
             .resourceOverrides(this, TimeoutSettings.Action.DELETE)
             .prompt(true)
             .until(() -> isDeleted(client));
-    }
-
-    @Override
-    public List<ValidationError> validate(Set<String> configuredFields) {
-        ArrayList<ValidationError> errors = new ArrayList<>();
-
-        // to make sure that the engine-version is not being downgraded
-        if (configuredFields.contains("engine-version") && getIdentifier() != null) {
-            RdsClient client = createClient(RdsClient.class);
-
-            try {
-                DescribeDbInstancesResponse response = client.describeDBInstances(
-                    r -> r.dbInstanceIdentifier(getIdentifier())
-                );
-
-                if (response.hasDbInstances() && !response.dbInstances().isEmpty()) {
-                    DBInstance dbInstance = response.dbInstances().get(0);
-                    String currentVersion = dbInstance.engineVersion();
-
-
-                    DescribeDbEngineVersionsResponse versionType = client.describeDBEngineVersions(
-                        DescribeDbEngineVersionsRequest.builder().engineVersion(currentVersion).build());
-
-                    if (versionType.hasDbEngineVersions() && !versionType.dbEngineVersions().isEmpty()) {
-                        if (!currentVersion.equals(getEngineVersion()) &&
-                            versionType.dbEngineVersions().get(0).validUpgradeTarget()
-                            .stream()
-                            .map(UpgradeTarget::engineVersion)
-                            .noneMatch(version -> version.equals(getEngineVersion()))) {
-                            errors.add(new ValidationError(
-                                this,
-                                "engine-version",
-                                String.format(
-                                    "'%s' is not a valid upgrade target for the current engine version '%s'.",
-                                    getEngineVersion(),
-                                    currentVersion
-                                )
-                            ));
-                        }
-                    }
-                }
-
-            } catch (DbInstanceNotFoundException ex) {
-                // ignore if db instance doesn't exist
-            }
-        }
-
-        return errors;
     }
 
     private boolean isDeleted(RdsClient client) {


### PR DESCRIPTION
Removes the extra validation for aurora engine versions.

For more context:
To ensure we don't even attempt to downgrade an aurora engine version upgraded by an `auto minor version update`, we skip refreshing that field in the copyfrom/refresh method(s).
By doing this, the state and the config file stays in sync unless the config is updated and also makes sure that automations don't fail. We tried to add validation to disallow manually downgrading a aurora version, but this interferes with the logic above.