### PR TITLE
Update DbGlobalClusterResource.java to support endpoint-address

### DIFF
--- a/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
+++ b/src/main/java/gyro/aws/rds/DbGlobalClusterResource.java
@@ -28,6 +28,7 @@ import gyro.core.TimeoutSettings;
 import gyro.core.Type;
 import gyro.core.Wait;
 import gyro.core.resource.Id;
+import gyro.core.resource.Output;
 import gyro.core.resource.Resource;
 import gyro.core.resource.Updatable;
 import gyro.core.scope.State;
@@ -60,6 +61,7 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
     private String identifier;
     private DbClusterResource sourceDbCluster;
     private Boolean storageEncrypted;
+    private String endpointAddress;
 
     /**
      * The name for your database of up to 64 alpha-numeric characters. If omitted, no database will be created in the global database cluster.
@@ -142,6 +144,18 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
         this.storageEncrypted = storageEncrypted;
     }
 
+    /**
+     * The writer endpoint for the global database cluster. This endpoint is used for write operations.
+     */
+    @Output
+    public String getEndpointAddress() {
+        return endpointAddress;
+    }
+
+    public void setEndpointAddress(String endpointAddress) {
+        this.endpointAddress = endpointAddress;
+    }
+
     @Override
     public void copyFrom(GlobalCluster cluster) {
         setDatabaseName(cluster.databaseName());
@@ -155,6 +169,7 @@ public class DbGlobalClusterResource extends AwsResource implements Copyable<Glo
 
         setEngineVersion(version);
         setStorageEncrypted(cluster.storageEncrypted());
+        setEndpointAddress(cluster.endpoint());
     }
 
     @Override


### PR DESCRIPTION
This pull request adds support for exposing the writer endpoint address for global database clusters in the `DbGlobalClusterResource` class. This allows users to easily retrieve the endpoint used for write operations.

Enhancements to output properties:

* Added a new `endpointAddress` property to `DbGlobalClusterResource`, annotated with `@Output`, to expose the writer endpoint address for global database clusters. [[1]](diffhunk://#diff-e821523d7d1e297182b272e1af256c6981f4a36481ec404255a8585b2a8715f3R64) [[2]](diffhunk://#diff-e821523d7d1e297182b272e1af256c6981f4a36481ec404255a8585b2a8715f3R147-R158)
* Updated the `copyFrom` method to set the new `endpointAddress` property from the underlying `GlobalCluster` model.
* Imported the `Output` annotation to support the new output property.